### PR TITLE
Add: linter hook

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -324,6 +324,8 @@ CheckOptions:
     value:           'lower_case'
   - key:             readability-identifier-naming.VariableCase
     value:           'lower_case'
+  - key:             readability-identifier-naming.ConstantCase
+    value:           'UPPER_CASE'
   - key:             readability-implicit-bool-conversion.AllowIntegerConditions
     value:           '0'
   - key:             readability-implicit-bool-conversion.AllowPointerConditions

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+function reformat_code () {
+	echo "---> Reformatting source"
+	clang-format -i -style=file $1
+}
+
+function lint_code () {
+	echo "---> Checking for linter warnings"
+	echo ""
+
+	clang-tidy \
+		-checks='' \
+		-header-filter='.*' \
+		$1 \
+		-- \
+		-std=c11
+}
+
+echo "---> Running pre-commit hooks"
+
+CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -Ee "\.[ch]$")
+
+if [[ $CHANGED_FILES = "" ]]
+then
+	echo "---> [warn] no c source was changed"
+else
+	reformat_code $CHANGED_FILES
+	lint_code $CHANGED_FILES
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing
+#Contributing
 
-Fork, then clone the repo:
+**Fork, then clone the repo:**
 
 ```bash
 git clone git@github.com:<your-username>/circ.git
 ```
 
-Install the dependencies:
+**Install the dependencies:**
 
 * `cmake`
 * `make`
@@ -14,9 +14,13 @@ Install the dependencies:
 * `libunistring-dev`
 * `libev-dev`
 
-Install the development dependencies (this is important!):
+**Install the development dependencies (this is important!):**
 
 * `clang` (for `clang-format`, `clang-tidy`)
+
+**Install the Git Hooks**
+
+Symlink `.githooks` to `.git/hooks`.
 
 Push to your fork, then [submit a pull request](https://github.com/nihilist-space/circ/compare/)
 


### PR DESCRIPTION
Ship an optional pre-commit hook that lints and reformats c source.

Also fixes a `clang-tidy` option for naming constants.