### PR TITLE
Add the event loop

### DIFF
--- a/circ.c
+++ b/circ.c
@@ -34,12 +34,8 @@ main (int argc, char** argv)
 		err (1, "");
 	puts ("sent nick/user info");
 
-	puts ("entering read/print loop");
-	char c;
-	/* While exactly one byte is read, print it back */
-	while (irc_read_bytes (&s, &c, 1) == 1)
-		/* Just print what the server says for now */
-		write (1, &c, 1);
+	puts ("entering event loop");
+	irc_do_event_loop(&s);
 
 	return 0;
 }

--- a/irc.c
+++ b/irc.c
@@ -13,7 +13,7 @@
 
 #include "irc.h"
 
-#define IRC_MESSAGE_SIZE (4096 + 1)	// IRCv3 message size + 1 for '\0'
+#define IRC_MESSAGE_SIZE 8192	// IRCv3 message size + 1 for '\0'
 
 typedef struct {
 	const irc_server *server;

--- a/irc.c
+++ b/irc.c
@@ -64,6 +64,8 @@ void irc_do_event_loop (const irc_server *s) {
 	irc_connection *conn = get_irc_server_connection (s);
 	struct ev_loop *loop = EV_DEFAULT;
 
+	pthread_mutex_init(&conn->ev_read_mtx, NULL);
+	pthread_mutex_init(&conn->ev_write_mtx, NULL);
 	ev_io_init (&conn->ev_watcher, irc_loop_callback, conn->socket, EV_READ);
 	ev_io_start (loop, &conn->ev_watcher);
 

--- a/irc.c
+++ b/irc.c
@@ -59,11 +59,7 @@ int irc_server_connect (const irc_server *s) {
 	return 0;
 }
 
-/*
- * Start an I/O event loop for reading server s.
- * Currently, a single server is supported. In the future this could be moved
- * to the irc_connection struct and be found back through the watcher.
- */
+/* Start an I/O event loop for reading server s. */
 void irc_do_event_loop (const irc_server *s) {
 	irc_connection *conn = get_irc_server_connection (s);
 	struct ev_loop *loop = EV_DEFAULT;
@@ -255,9 +251,7 @@ irc_connection *get_irc_server_connection (const irc_server *s) {
 	return NULL;
 }
 
-/*
- * Return the irc_connection for the server watched by the given watcher
- */
+/* Return the irc_connection for the server watched by the given watcher */
 irc_connection *get_irc_connection_from_watcher (const ev_io *w) {
 	int i;
 	for (i = 0; conns[i] != NULL; i++) {

--- a/irc.c
+++ b/irc.c
@@ -97,7 +97,6 @@ static void irc_loop_callback (EV_P_ ev_io *w, int re) {
 
 /* irc_read_message reads an IRC message to a buffer */
 int irc_read_message (const irc_server *s, char buf[IRC_MESSAGE_SIZE]) {
-	char c[2];
 	int i, n = 1;
 
 	for (i = 0; buf[i - 1] != '\r' && buf[i] != '\n'; i++)

--- a/irc.h
+++ b/irc.h
@@ -3,11 +3,13 @@
 typedef struct {
 	char *name;		// Server name
 	char *host;		// Server host
-	char *port;		// Connection port 
+	char *port;		// Connection port
 	char **channels;	// Joined channels (or to join)
 	bool use_TLS;		// Whether to use TLS
 } irc_server;
 
 int irc_server_connect (const irc_server *);
+void irc_do_event_loop (const irc_server *);
+int irc_read_message (const irc_server *, char *);
 int irc_read_bytes (const irc_server *, char *, size_t);
 int irc_write_bytes (const irc_server *, char *, size_t);


### PR DESCRIPTION
This change implies an interface for the modules handler where messages to send back to the server are returned in an array by a certain function, which wouldn't be too hard to implement and abstracts all of the reading and writing into irc.c, which is pretty desirable.

We're asynchronous on message handling but synchronized for reading and writing to prevent strange behaviour on the socket.