### PR TITLE
Implement fully async I/O through libev, along with some fixes

### DIFF
--- a/src/circ.c
+++ b/src/circ.c
@@ -34,12 +34,9 @@ main (int argc, char** argv)
 	char* realname = getenv ("CIRC_REALNAME");
 	char* sasl_enabled = getenv ("CIRC_SASL_ENABLED");
 
-
-
-
 	log_info ("setting up connection\n");
 	int ret = irc_server_connect (&s);
-	if (ret == -1) {
+	if (ret == -1 || errno) {
 		err (1, "Error Connecting");
 	}
 	log_info ("connection setup\n");


### PR DESCRIPTION
* Message processing is now queue-based
* Add a timeout watcher to the event loop
* Push message processing to handle_message, outside of the event loop
* Changed check_socket for verify_socket
* Fix some warnings
* Push the call to setnonblock to after the TLS setup to avoid an error
* Check whether the socket is invalid only after we're done looping over addrinfo
* Check for errno after irc_server_connect