### PR TITLE
Implement IRC hooks and move most code to it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(circ
   "lib/log/log.c"
   "lib/log/log.h"
   "lib/irc/irc.c"
+  "lib/irc/hooks.c"
   "lib/b64/decode.c"
   "lib/b64/encode.c"
   "src/circ.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(circ
   "lib/log/log.h"
   "lib/irc/irc.c"
   "lib/irc/hooks.c"
+  "lib/irc/core_hooks.c"
   "lib/b64/decode.c"
   "lib/b64/encode.c"
   "src/circ.c"

--- a/lib/b64/b64.h
+++ b/lib/b64/b64.h
@@ -13,10 +13,10 @@
  */
 
 #ifndef b64_malloc
-#  define b64_malloc(ptr) malloc(ptr)
+#define b64_malloc(ptr) malloc (ptr)
 #endif
 #ifndef b64_realloc
-#  define b64_realloc(ptr, size) realloc(ptr, size)
+#define b64_realloc(ptr, size) realloc (ptr, size)
 #endif
 
 /**
@@ -24,41 +24,37 @@
  */
 
 static const char b64_table[] = {
-  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
-  'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-  'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
-  'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
-  'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
-  'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-  'w', 'x', 'y', 'z', '0', '1', '2', '3',
-  '4', '5', '6', '7', '8', '9', '+', '/'
+	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+	'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+	'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+	'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+	'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
 };
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/**
- * Encode `unsigned char *' source with `size_t' size.
- * Returns a `char *' base64 encoded string.
- */
+	/**
+	 * Encode `unsigned char *' source with `size_t' size.
+	 * Returns a `char *' base64 encoded string.
+	 */
 
-char *
-b64_encode (char *, size_t);
+	char* b64_encode (char*, size_t);
 
-/**
- * Dencode `char *' source with `size_t' size.
- * Returns a `unsigned char *' base64 decoded string.
- */
-unsigned char *
-b64_decode (const char *, size_t);
+	/**
+	 * Dencode `char *' source with `size_t' size.
+	 * Returns a `unsigned char *' base64 decoded string.
+	 */
+	unsigned char* b64_decode (const char*, size_t);
 
-/**
- * Dencode `char *' source with `size_t' size.
- * Returns a `unsigned char *' base64 decoded string + size of decoded string.
- */
-unsigned char *
-b64_decode_ex (const char *, size_t, size_t *);
+	/**
+	 * Dencode `char *' source with `size_t' size.
+	 * Returns a `unsigned char *' base64 decoded string + size of decoded
+	 * string.
+	 */
+	unsigned char* b64_decode_ex (const char*, size_t, size_t*);
 
 #ifdef __cplusplus
 }

--- a/lib/b64/decode.c
+++ b/lib/b64/decode.c
@@ -4,126 +4,136 @@
  * copyright (c) 2014 joseph werle
  */
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <ctype.h>
+
 #include "b64.h"
 
 #ifdef b64_USE_CUSTOM_MALLOC
-extern void* b64_malloc(size_t);
+extern void* b64_malloc (size_t);
 #endif
 
 #ifdef b64_USE_CUSTOM_REALLOC
-extern void* b64_realloc(void*, size_t);
+extern void*
+b64_realloc (void*, size_t);
 #endif
 
-unsigned char *
-b64_decode (const char *src, size_t len) {
-  return b64_decode_ex(src, len, NULL);
+unsigned char*
+b64_decode (const char* src, size_t len)
+{
+	return b64_decode_ex (src, len, NULL);
 }
 
-unsigned char *
-b64_decode_ex (const char *src, size_t len, size_t *decsize) {
-  int i = 0;
-  int j = 0;
-  int l = 0;
-  size_t size = 0;
-  unsigned char *dec = NULL;
-  unsigned char buf[3];
-  unsigned char tmp[4];
+unsigned char*
+b64_decode_ex (const char* src, size_t len, size_t* decsize)
+{
+	int i = 0;
+	int j = 0;
+	int l = 0;
+	size_t size = 0;
+	unsigned char* dec = NULL;
+	unsigned char buf[3];
+	unsigned char tmp[4];
 
-  // alloc
-  dec = (unsigned char *) b64_malloc(1);
-  if (NULL == dec) { return NULL; }
+	// alloc
+	dec = (unsigned char*)b64_malloc (1);
+	if (NULL == dec) {
+		return NULL;
+	}
 
-  // parse until end of source
-  while (len--) {
-    // break if char is `=' or not base64 char
-    if ('=' == src[j]) { break; }
-    if (!(isalnum(src[j]) || '+' == src[j] || '/' == src[j])) { break; }
+	// parse until end of source
+	while (len--) {
+		// break if char is `=' or not base64 char
+		if ('=' == src[j]) {
+			break;
+		}
+		if (!(isalnum (src[j]) || '+' == src[j] || '/' == src[j])) {
+			break;
+		}
 
-    // read up to 4 bytes at a time into `tmp'
-    tmp[i++] = src[j++];
+		// read up to 4 bytes at a time into `tmp'
+		tmp[i++] = src[j++];
 
-    // if 4 bytes read then decode into `buf'
-    if (4 == i) {
-      // translate values in `tmp' from table
-      for (i = 0; i < 4; ++i) {
-        // find translation char in `b64_table'
-        for (l = 0; l < 64; ++l) {
-          if (tmp[i] == b64_table[l]) {
-            tmp[i] = l;
-            break;
-          }
-        }
-      }
+		// if 4 bytes read then decode into `buf'
+		if (4 == i) {
+			// translate values in `tmp' from table
+			for (i = 0; i < 4; ++i) {
+				// find translation char in `b64_table'
+				for (l = 0; l < 64; ++l) {
+					if (tmp[i] == b64_table[l]) {
+						tmp[i] = l;
+						break;
+					}
+				}
+			}
 
-      // decode
-      buf[0] = (tmp[0] << 2) + ((tmp[1] & 0x30) >> 4);
-      buf[1] = ((tmp[1] & 0xf) << 4) + ((tmp[2] & 0x3c) >> 2);
-      buf[2] = ((tmp[2] & 0x3) << 6) + tmp[3];
+			// decode
+			buf[0] = (tmp[0] << 2) + ((tmp[1] & 0x30) >> 4);
+			buf[1] = ((tmp[1] & 0xf) << 4) + ((tmp[2] & 0x3c) >> 2);
+			buf[2] = ((tmp[2] & 0x3) << 6) + tmp[3];
 
-      // write decoded buffer to `dec'
-      dec = (unsigned char *) b64_realloc(dec, size + 3);
-      if (dec != NULL){
-        for (i = 0; i < 3; ++i) {
-          dec[size++] = buf[i];
-        }
-      } else {
-        return NULL;
-      }
+			// write decoded buffer to `dec'
+			dec = (unsigned char*)b64_realloc (dec, size + 3);
+			if (dec != NULL) {
+				for (i = 0; i < 3; ++i) {
+					dec[size++] = buf[i];
+				}
+			} else {
+				return NULL;
+			}
 
-      // reset
-      i = 0;
-    }
-  }
+			// reset
+			i = 0;
+		}
+	}
 
-  // remainder
-  if (i > 0) {
-    // fill `tmp' with `\0' at most 4 times
-    for (j = i; j < 4; ++j) {
-      tmp[j] = '\0';
-    }
+	// remainder
+	if (i > 0) {
+		// fill `tmp' with `\0' at most 4 times
+		for (j = i; j < 4; ++j) {
+			tmp[j] = '\0';
+		}
 
-    // translate remainder
-    for (j = 0; j < 4; ++j) {
-        // find translation char in `b64_table'
-        for (l = 0; l < 64; ++l) {
-          if (tmp[j] == b64_table[l]) {
-            tmp[j] = l;
-            break;
-          }
-        }
-    }
+		// translate remainder
+		for (j = 0; j < 4; ++j) {
+			// find translation char in `b64_table'
+			for (l = 0; l < 64; ++l) {
+				if (tmp[j] == b64_table[l]) {
+					tmp[j] = l;
+					break;
+				}
+			}
+		}
 
-    // decode remainder
-    buf[0] = (tmp[0] << 2) + ((tmp[1] & 0x30) >> 4);
-    buf[1] = ((tmp[1] & 0xf) << 4) + ((tmp[2] & 0x3c) >> 2);
-    buf[2] = ((tmp[2] & 0x3) << 6) + tmp[3];
+		// decode remainder
+		buf[0] = (tmp[0] << 2) + ((tmp[1] & 0x30) >> 4);
+		buf[1] = ((tmp[1] & 0xf) << 4) + ((tmp[2] & 0x3c) >> 2);
+		buf[2] = ((tmp[2] & 0x3) << 6) + tmp[3];
 
-    // write remainer decoded buffer to `dec'
-    dec = (unsigned char *) b64_realloc(dec, size + (i - 1));
-    if (dec != NULL){
-      for (j = 0; (j < i - 1); ++j) {
-        dec[size++] = buf[j];
-      }
-    } else {
-      return NULL;
-    }
-  }
+		// write remainer decoded buffer to `dec'
+		dec = (unsigned char*)b64_realloc (dec, size + (i - 1));
+		if (dec != NULL) {
+			for (j = 0; (j < i - 1); ++j) {
+				dec[size++] = buf[j];
+			}
+		} else {
+			return NULL;
+		}
+	}
 
-  // Make sure we have enough space to add '\0' character at end.
-  dec = (unsigned char *) b64_realloc(dec, size + 1);
-  if (dec != NULL){
-    dec[size] = '\0';
-  } else {
-    return NULL;
-  }
+	// Make sure we have enough space to add '\0' character at end.
+	dec = (unsigned char*)b64_realloc (dec, size + 1);
+	if (dec != NULL) {
+		dec[size] = '\0';
+	} else {
+		return NULL;
+	}
 
-  // Return back the size of decoded string if demanded.
-  if (decsize != NULL) {
-    *decsize = size;
-  }
+	// Return back the size of decoded string if demanded.
+	if (decsize != NULL) {
+		*decsize = size;
+	}
 
-  return dec;
+	return dec;
 }

--- a/lib/b64/encode.c
+++ b/lib/b64/encode.c
@@ -6,85 +6,90 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "b64.h"
 
 #ifdef b64_USE_CUSTOM_MALLOC
-extern void* b64_malloc(size_t);
+extern void* b64_malloc (size_t);
 #endif
 
 #ifdef b64_USE_CUSTOM_REALLOC
-extern void* b64_realloc(void*, size_t);
+extern void*
+b64_realloc (void*, size_t);
 #endif
 
-char *
-b64_encode (char *src, size_t len) {
-  int i = 0;
-  int j = 0;
-  char *enc = NULL;
-  size_t size = 0;
-  unsigned char buf[4];
-  unsigned char tmp[3];
+char*
+b64_encode (char* src, size_t len)
+{
+	int i = 0;
+	int j = 0;
+	char* enc = NULL;
+	size_t size = 0;
+	unsigned char buf[4];
+	unsigned char tmp[3];
 
-  // alloc
-  enc = (char *) b64_malloc(1);
-  if (NULL == enc) { return NULL; }
+	// alloc
+	enc = (char*)b64_malloc (1);
+	if (NULL == enc) {
+		return NULL;
+	}
 
-  // parse until end of source
-  while (len--) {
-    // read up to 3 bytes at a time into `tmp'
-    tmp[i++] = *(src++);
+	// parse until end of source
+	while (len--) {
+		// read up to 3 bytes at a time into `tmp'
+		tmp[i++] = *(src++);
 
-    // if 3 bytes read then encode into `buf'
-    if (3 == i) {
-      buf[0] = (tmp[0] & 0xfc) >> 2;
-      buf[1] = ((tmp[0] & 0x03) << 4) + ((tmp[1] & 0xf0) >> 4);
-      buf[2] = ((tmp[1] & 0x0f) << 2) + ((tmp[2] & 0xc0) >> 6);
-      buf[3] = tmp[2] & 0x3f;
+		// if 3 bytes read then encode into `buf'
+		if (3 == i) {
+			buf[0] = (tmp[0] & 0xfc) >> 2;
+			buf[1] = ((tmp[0] & 0x03) << 4) + ((tmp[1] & 0xf0) >> 4);
+			buf[2] = ((tmp[1] & 0x0f) << 2) + ((tmp[2] & 0xc0) >> 6);
+			buf[3] = tmp[2] & 0x3f;
 
-      // allocate 4 new byts for `enc` and
-      // then translate each encoded buffer
-      // part by index from the base 64 index table
-      // into `enc' unsigned char array
-      enc = (char *) b64_realloc(enc, size + 4);
-      for (i = 0; i < 4; ++i) {
-        enc[size++] = b64_table[buf[i]];
-      }
+			// allocate 4 new byts for `enc` and
+			// then translate each encoded buffer
+			// part by index from the base 64 index table
+			// into `enc' unsigned char array
+			enc = (char*)b64_realloc (enc, size + 4);
+			for (i = 0; i < 4; ++i) {
+				enc[size++] = b64_table[buf[i]];
+			}
 
-      // reset index
-      i = 0;
-    }
-  }
+			// reset index
+			i = 0;
+		}
+	}
 
-  // remainder
-  if (i > 0) {
-    // fill `tmp' with `\0' at most 3 times
-    for (j = i; j < 3; ++j) {
-      tmp[j] = '\0';
-    }
+	// remainder
+	if (i > 0) {
+		// fill `tmp' with `\0' at most 3 times
+		for (j = i; j < 3; ++j) {
+			tmp[j] = '\0';
+		}
 
-    // perform same codec as above
-    buf[0] = (tmp[0] & 0xfc) >> 2;
-    buf[1] = ((tmp[0] & 0x03) << 4) + ((tmp[1] & 0xf0) >> 4);
-    buf[2] = ((tmp[1] & 0x0f) << 2) + ((tmp[2] & 0xc0) >> 6);
-    buf[3] = tmp[2] & 0x3f;
+		// perform same codec as above
+		buf[0] = (tmp[0] & 0xfc) >> 2;
+		buf[1] = ((tmp[0] & 0x03) << 4) + ((tmp[1] & 0xf0) >> 4);
+		buf[2] = ((tmp[1] & 0x0f) << 2) + ((tmp[2] & 0xc0) >> 6);
+		buf[3] = tmp[2] & 0x3f;
 
-    // perform same write to `enc` with new allocation
-    for (j = 0; (j < i + 1); ++j) {
-      enc = (char *) b64_realloc(enc, size + 1);
-      enc[size++] = b64_table[buf[j]];
-    }
+		// perform same write to `enc` with new allocation
+		for (j = 0; (j < i + 1); ++j) {
+			enc = (char*)b64_realloc (enc, size + 1);
+			enc[size++] = b64_table[buf[j]];
+		}
 
-    // while there is still a remainder
-    // append `=' to `enc'
-    while ((i++ < 3)) {
-      enc = (char *) b64_realloc(enc, size + 1);
-      enc[size++] = '=';
-    }
-  }
+		// while there is still a remainder
+		// append `=' to `enc'
+		while ((i++ < 3)) {
+			enc = (char*)b64_realloc (enc, size + 1);
+			enc[size++] = '=';
+		}
+	}
 
-  // Make sure we have enough space to add '\0' character at end.
-  enc = (char *) b64_realloc(enc, size + 1);
-  enc[size] = '\0';
+	// Make sure we have enough space to add '\0' character at end.
+	enc = (char*)b64_realloc (enc, size + 1);
+	enc[size] = '\0';
 
-  return enc;
+	return enc;
 }

--- a/lib/config/config.c
+++ b/lib/config/config.c
@@ -1,5 +1,5 @@
-#include "log/log.h"
 #include "config.h"
+#include "log/log.h"
 #include <stdlib.h>
 
 char*

--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -1,28 +1,31 @@
 // nice macro from https://stackoverflow.com/a/10966395/3474615
 
-#define FOREACH_CONFIG_KEY(T) \
-  T(SERVER) \
-  T(PORT) \
-  T(SSL) \
-  T(NICK) \
-  T(IDENT) \
-  T(REALNAME) \
-  T(SASL_ENABLED) \
-  T(AUTH_USER) \
-  T(AUTH_PASS) \
-  T(CHANNEL)
+#define FOREACH_CONFIG_KEY(T)                                                  \
+	T (SERVER)                                                                 \
+	T (PORT)                                                                   \
+	T (SSL)                                                                    \
+	T (NICK)                                                                   \
+	T (IDENT)                                                                  \
+	T (REALNAME)                                                               \
+	T (SASL_ENABLED)                                                           \
+	T (AUTH_USER)                                                              \
+	T (AUTH_PASS)                                                              \
+	T (CHANNEL)
 
-#define GENERATE_ENUM(ENUM) CIRC_ ## ENUM,
+#define GENERATE_ENUM(ENUM) CIRC_##ENUM,
 #define GENERATE_STRING(STRING) "CIRC_" #STRING,
 
-enum CONFIG_KEY_ENUM {
-  FOREACH_CONFIG_KEY(GENERATE_ENUM)
+enum CONFIG_KEY_ENUM
+{
+	FOREACH_CONFIG_KEY (GENERATE_ENUM)
 };
 
-static const char *CONFIG_KEY_STRING[] = {
-  FOREACH_CONFIG_KEY(GENERATE_STRING)
-};
+static const char* CONFIG_KEY_STRING[] = { FOREACH_CONFIG_KEY (
+  GENERATE_STRING) };
 
-char* get_config_value (const char* key);
-int get_config_length ();
-void print_config ();
+char*
+get_config_value (const char* key);
+int
+get_config_length ();
+void
+print_config ();

--- a/lib/irc-parser/ircium-message-tag.c
+++ b/lib/irc-parser/ircium-message-tag.c
@@ -25,13 +25,14 @@ struct _IrciumMessageTag
 {
 	GObject parent_instance;
 
-	gchar *name;
-	gchar *value;
+	gchar* name;
+	gchar* value;
 };
 
 G_DEFINE_TYPE (IrciumMessageTag, ircium_message_tag, G_TYPE_OBJECT)
 
-enum {
+enum
+{
 	PROP_0,
 
 	PROP_NAME,
@@ -40,36 +41,31 @@ enum {
 	N_PROPS
 };
 
-static GParamSpec *properties [N_PROPS];
+static GParamSpec* properties[N_PROPS];
 
-IrciumMessageTag *
+IrciumMessageTag*
 ircium_message_tag_new (void)
 {
 	return g_object_new (IRCIUM_TYPE_MESSAGE_TAG, NULL);
 }
 
-IrciumMessageTag *
-ircium_message_tag_new_with_name (gchar *name)
+IrciumMessageTag*
+ircium_message_tag_new_with_name (gchar* name)
 {
-	return g_object_new (IRCIUM_TYPE_MESSAGE_TAG,
-			     "name", name,
-			     NULL);
+	return g_object_new (IRCIUM_TYPE_MESSAGE_TAG, "name", name, NULL);
 }
 
-IrciumMessageTag *
-ircium_message_tag_new_with_name_and_value (gchar *name,
-                                            gchar *value)
+IrciumMessageTag*
+ircium_message_tag_new_with_name_and_value (gchar* name, gchar* value)
 {
-	return g_object_new (IRCIUM_TYPE_MESSAGE_TAG,
-			     "name", name,
-			     "value", value,
-			     NULL);
+	return g_object_new (
+	  IRCIUM_TYPE_MESSAGE_TAG, "name", name, "value", value, NULL);
 }
 
 static void
-ircium_message_tag_finalize (GObject *object)
+ircium_message_tag_finalize (GObject* object)
 {
-	IrciumMessageTag *self = (IrciumMessageTag *)object;
+	IrciumMessageTag* self = (IrciumMessageTag*)object;
 
 	g_clear_pointer (&self->name, g_free);
 	g_clear_pointer (&self->value, g_free);
@@ -78,88 +74,83 @@ ircium_message_tag_finalize (GObject *object)
 }
 
 static void
-ircium_message_tag_get_property (GObject    *object,
-                                 guint       prop_id,
-                                 GValue     *value,
-                                 GParamSpec *pspec)
+ircium_message_tag_get_property (GObject* object,
+                                 guint prop_id,
+                                 GValue* value,
+                                 GParamSpec* pspec)
 {
-	IrciumMessageTag *self = IRCIUM_MESSAGE_TAG (object);
+	IrciumMessageTag* self = IRCIUM_MESSAGE_TAG (object);
 
-	switch (prop_id)
-	{
-	case PROP_NAME:
-		g_value_set_string (value, self->name);
-		break;
-	case PROP_VALUE:
-		g_value_set_string (value, self->value);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+	switch (prop_id) {
+		case PROP_NAME:
+			g_value_set_string (value, self->name);
+			break;
+		case PROP_VALUE:
+			g_value_set_string (value, self->value);
+			break;
+		default:
+			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 	}
 }
 
 static void
-ircium_message_tag_set_property (GObject      *object,
-                                 guint         prop_id,
-                                 const GValue *value,
-                                 GParamSpec   *pspec)
+ircium_message_tag_set_property (GObject* object,
+                                 guint prop_id,
+                                 const GValue* value,
+                                 GParamSpec* pspec)
 {
-	IrciumMessageTag *self = IRCIUM_MESSAGE_TAG (object);
+	IrciumMessageTag* self = IRCIUM_MESSAGE_TAG (object);
 
-	switch (prop_id)
-	{
-	case PROP_NAME:
-		self->name = g_value_dup_string (value);
-		break;
-	case PROP_VALUE:
-		self->value = g_value_dup_string (value);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+	switch (prop_id) {
+		case PROP_NAME:
+			self->name = g_value_dup_string (value);
+			break;
+		case PROP_VALUE:
+			self->value = g_value_dup_string (value);
+			break;
+		default:
+			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 	}
 }
 
 static void
-ircium_message_tag_class_init (IrciumMessageTagClass *klass)
+ircium_message_tag_class_init (IrciumMessageTagClass* klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	GObjectClass* object_class = G_OBJECT_CLASS (klass);
 
 	object_class->finalize = ircium_message_tag_finalize;
 	object_class->get_property = ircium_message_tag_get_property;
 	object_class->set_property = ircium_message_tag_set_property;
 
-	properties[PROP_NAME] = g_param_spec_string
-		("name",
-		 "name",
-		 "The name of this tag",
-		 NULL,
-		 G_PARAM_READWRITE |
-		 G_PARAM_CONSTRUCT);
-	properties[PROP_VALUE] = g_param_spec_string
-		("value",
-		 "value",
-		 "The value of this tag, if one exists",
-		 NULL,
-		 G_PARAM_READWRITE |
-		 G_PARAM_CONSTRUCT);
+	properties[PROP_NAME] =
+	  g_param_spec_string ("name",
+	                       "name",
+	                       "The name of this tag",
+	                       NULL,
+	                       G_PARAM_READWRITE | G_PARAM_CONSTRUCT);
+	properties[PROP_VALUE] =
+	  g_param_spec_string ("value",
+	                       "value",
+	                       "The value of this tag, if one exists",
+	                       NULL,
+	                       G_PARAM_READWRITE | G_PARAM_CONSTRUCT);
 
 	g_object_class_install_properties (object_class, N_PROPS, properties);
 }
 
 static void
-ircium_message_tag_init (IrciumMessageTag *self)
-{
-}
+ircium_message_tag_init (IrciumMessageTag* self)
+{}
 
-const gchar *
-ircium_message_tag_get_name (IrciumMessageTag *tag)
+const gchar*
+ircium_message_tag_get_name (IrciumMessageTag* tag)
 {
 	g_return_val_if_fail (IRCIUM_IS_MESSAGE_TAG (tag), NULL);
 	return tag->name;
 }
 
 void
-ircium_message_tag_set_name (IrciumMessageTag *tag, gchar *name)
+ircium_message_tag_set_name (IrciumMessageTag* tag, gchar* name)
 {
 	g_return_if_fail (IRCIUM_IS_MESSAGE_TAG (tag));
 
@@ -167,15 +158,15 @@ ircium_message_tag_set_name (IrciumMessageTag *tag, gchar *name)
 	tag->name = g_strdup (name);
 }
 
-const gchar *
-ircium_message_tag_get_value (IrciumMessageTag *tag)
+const gchar*
+ircium_message_tag_get_value (IrciumMessageTag* tag)
 {
 	g_return_val_if_fail (IRCIUM_IS_MESSAGE_TAG (tag), NULL);
 	return tag->value;
 }
 
 void
-ircium_message_tag_set_value (IrciumMessageTag *tag, gchar *value)
+ircium_message_tag_set_value (IrciumMessageTag* tag, gchar* value)
 {
 	g_return_if_fail (IRCIUM_IS_MESSAGE_TAG (tag));
 
@@ -184,66 +175,65 @@ ircium_message_tag_set_value (IrciumMessageTag *tag, gchar *value)
 }
 
 gboolean
-ircium_message_tag_has_value (IrciumMessageTag *tag)
+ircium_message_tag_has_value (IrciumMessageTag* tag)
 {
 	g_return_val_if_fail (IRCIUM_IS_MESSAGE_TAG (tag), FALSE);
 	return tag->value != NULL;
 }
 
-gchar *
-ircium_message_tag_escape_string (const gchar *str)
+gchar*
+ircium_message_tag_escape_string (const gchar* str)
 {
 	gsize final_str_len = 0;
-	for (const gchar *iter = str; (*iter) != '\0'; ++iter) {
-		switch (*iter)
-		{
-		case ';':
-			final_str_len += 2;
-			break;
-		case ' ':
-			final_str_len += 2;
-			break;
-		case '\\':
-			final_str_len += 2;
-			break;
-		case '\r':
-			final_str_len += 2;
-			break;
-		case '\n':
-			final_str_len += 2;
-			break;
-		default:
-			final_str_len += 1;
-			break;
+	for (const gchar* iter = str; (*iter) != '\0'; ++iter) {
+		switch (*iter) {
+			case ';':
+				final_str_len += 2;
+				break;
+			case ' ':
+				final_str_len += 2;
+				break;
+			case '\\':
+				final_str_len += 2;
+				break;
+			case '\r':
+				final_str_len += 2;
+				break;
+			case '\n':
+				final_str_len += 2;
+				break;
+			default:
+				final_str_len += 1;
+				break;
 		}
 	}
-	gchar *ret = g_malloc0 (final_str_len + 1);
+	gchar* ret = g_malloc0 (final_str_len + 1);
 	gsize pos = 0;
-	for (const gchar *iter = str; *iter != '\0'; ++iter) {
+	for (const gchar* iter = str; *iter != '\0'; ++iter) {
 		switch (*iter) {
-		case ';':
-			ret[pos] = '\\';
-			ret[++pos] = ':';
-			break;
-		case ' ':
-			ret[pos] = '\\';
-			ret[++pos] = 's';
-			break;
-		case '\\':
-			ret[pos] = '\\';
-			ret[++pos] = '\\';
-			break;
-		case '\r':
-			ret[pos] = '\\';
-			ret[++pos] = 'r';
-			break;
-		case '\n':
-			ret[pos] = '\\';
-			ret[++pos] = 'n';
-			break;
-		default:
-			ret[pos] = *iter;
-			break;
+			case ';':
+				ret[pos] = '\\';
+				ret[++pos] = ':';
+				break;
+			case ' ':
+				ret[pos] = '\\';
+				ret[++pos] = 's';
+				break;
+			case '\\':
+				ret[pos] = '\\';
+				ret[++pos] = '\\';
+				break;
+			case '\r':
+				ret[pos] = '\\';
+				ret[++pos] = 'r';
+				break;
+			case '\n':
+				ret[pos] = '\\';
+				ret[++pos] = 'n';
+				break;
+			default:
+				ret[pos] = *iter;
+				break;
 		}
 		++pos;
 	}
@@ -251,32 +241,32 @@ ircium_message_tag_escape_string (const gchar *str)
 	return ret;
 }
 
-gchar *
-ircium_message_tag_unescape_string (const gchar *str)
+gchar*
+ircium_message_tag_unescape_string (const gchar* str)
 {
 	gsize final_str_len = 0;
-	for (const gchar *iter = str; *iter != '\0';) {
+	for (const gchar* iter = str; *iter != '\0';) {
 		if (*iter == '\\') {
 			switch (*++iter) {
-			case '\0':
-				continue;
-			case ':':
-				++final_str_len;
-				break;
-			case 's':
-				++final_str_len;
-				break;
-			case '\\':
-				++final_str_len;
-				break;
-			case 'r':
-				++final_str_len;
-				break;
-			case 'n':
-				++final_str_len;
-				break;
-			default:
-				break;
+				case '\0':
+					continue;
+				case ':':
+					++final_str_len;
+					break;
+				case 's':
+					++final_str_len;
+					break;
+				case '\\':
+					++final_str_len;
+					break;
+				case 'r':
+					++final_str_len;
+					break;
+				case 'n':
+					++final_str_len;
+					break;
+				default:
+					break;
 			}
 			++iter;
 			continue;
@@ -285,36 +275,36 @@ ircium_message_tag_unescape_string (const gchar *str)
 		++iter;
 	}
 
-	gchar *ret = g_malloc0 (final_str_len + 1);
+	gchar* ret = g_malloc0 (final_str_len + 1);
 
 	gsize pos = 0;
-	for (const gchar *iter = str; *iter != '\0';) {
+	for (const gchar* iter = str; *iter != '\0';) {
 		if (*iter == '\\') {
 			switch (*++iter) {
-			case '\0':
-				continue;
-			case ':':
-				ret[pos++] = ';';
-				++iter;
-				break;
-			case 's':
-				ret[pos++] = ' ';
-				++iter;
-				break;
-			case '\\':
-				ret[pos++] = '\\';
-				++iter;
-				break;
-			case 'r':
-				ret[pos++] = '\r';
-				++iter;
-				break;
-			case 'n':
-				ret[pos++] = '\n';
-				++iter;
-				break;
-			default:
-				break;
+				case '\0':
+					continue;
+				case ':':
+					ret[pos++] = ';';
+					++iter;
+					break;
+				case 's':
+					ret[pos++] = ' ';
+					++iter;
+					break;
+				case '\\':
+					ret[pos++] = '\\';
+					++iter;
+					break;
+				case 'r':
+					ret[pos++] = '\r';
+					++iter;
+					break;
+				case 'n':
+					ret[pos++] = '\n';
+					++iter;
+					break;
+				default:
+					break;
 			}
 			continue;
 		}

--- a/lib/irc-parser/ircium-message-tag.h
+++ b/lib/irc-parser/ircium-message-tag.h
@@ -25,25 +25,35 @@
 
 G_BEGIN_DECLS
 
-#define IRCIUM_TYPE_MESSAGE_TAG (ircium_message_tag_get_type())
+#define IRCIUM_TYPE_MESSAGE_TAG (ircium_message_tag_get_type ())
 
 G_DECLARE_FINAL_TYPE (IrciumMessageTag,
-		      ircium_message_tag,
-		      IRCIUM, MESSAGE_TAG,
-		      GObject)
+                      ircium_message_tag,
+                      IRCIUM,
+                      MESSAGE_TAG,
+                      GObject)
 
-IrciumMessageTag *ircium_message_tag_new (void);
-IrciumMessageTag *ircium_message_tag_new_with_name (gchar *name);
-IrciumMessageTag *ircium_message_tag_new_with_name_and_value (gchar *name,
-                                                              gchar *value);
+IrciumMessageTag*
+ircium_message_tag_new (void);
+IrciumMessageTag*
+ircium_message_tag_new_with_name (gchar* name);
+IrciumMessageTag*
+ircium_message_tag_new_with_name_and_value (gchar* name, gchar* value);
 
-const gchar *ircium_message_tag_get_name (IrciumMessageTag *tag);
-void ircium_message_tag_set_name (IrciumMessageTag *tag, gchar *name);
-const gchar *ircium_message_tag_get_value (IrciumMessageTag *tag);
-void ircium_message_tag_set_value (IrciumMessageTag *tag, gchar *value);
-gboolean ircium_message_tag_has_value (IrciumMessageTag *tag);
+const gchar*
+ircium_message_tag_get_name (IrciumMessageTag* tag);
+void
+ircium_message_tag_set_name (IrciumMessageTag* tag, gchar* name);
+const gchar*
+ircium_message_tag_get_value (IrciumMessageTag* tag);
+void
+ircium_message_tag_set_value (IrciumMessageTag* tag, gchar* value);
+gboolean
+ircium_message_tag_has_value (IrciumMessageTag* tag);
 
-gchar *ircium_message_tag_escape_string (const gchar *str);
-gchar *ircium_message_tag_unescape_string (const gchar *str);
+gchar*
+ircium_message_tag_escape_string (const gchar* str);
+gchar*
+ircium_message_tag_unescape_string (const gchar* str);
 
 G_END_DECLS

--- a/lib/irc-parser/ircium-message.c
+++ b/lib/irc-parser/ircium-message.c
@@ -40,8 +40,8 @@ ircium_message_new_real (void)
 
 IrciumMessage*
 ircium_message_new (GPtrArray* tags,
-                    gchar* source,
-                    gchar* cmd,
+                    const gchar* source,
+                    const gchar* cmd,
                     GPtrArray* params)
 {
 	IrciumMessage* ret = ircium_message_new_real ();
@@ -114,7 +114,7 @@ tag_val (const guint8* head, const guint8* iter)
 }
 
 IrciumMessage*
-ircium_message_parse (GByteArray* bytes, gboolean has_tag_cap)
+ircium_message_parse (const GByteArray* bytes, const gboolean has_tag_cap)
 {
 	IrciumMessage* msg = NULL;
 
@@ -278,33 +278,34 @@ ret:
 }
 
 const GPtrArray*
-ircium_message_get_tags (IrciumMessage* msg)
+ircium_message_get_tags (const IrciumMessage* msg)
 {
 	return msg->tags;
 }
 
 const gchar*
-ircium_message_get_source (IrciumMessage* msg)
+ircium_message_get_source (const IrciumMessage* msg)
 {
 	return msg->source;
 }
 
 const gchar*
-ircium_message_get_command (IrciumMessage* msg)
+ircium_message_get_command (const IrciumMessage* msg)
 {
 	return msg->command;
 }
 
 const GPtrArray*
-ircium_message_get_params (IrciumMessage* msg)
+ircium_message_get_params (const IrciumMessage* msg)
 {
 	return msg->params;
 }
 
 GBytes*
-ircium_message_serialize (IrciumMessage* msg)
+ircium_message_serialize (const IrciumMessage* msg)
 {
-	g_return_val_if_fail (IRCIUM_IS_MESSAGE (msg), NULL);
+	if (msg == NULL)
+		return NULL;
 
 	// First, we serialize the tags if we have any.
 	gchar* serialized_tags = NULL;

--- a/lib/irc-parser/ircium-message.c
+++ b/lib/irc-parser/ircium-message.c
@@ -24,27 +24,27 @@ struct _IrciumMessage
 {
 	GObject parent_instance;
 
-	GPtrArray *tags;
-	gchar *source;
-	gchar *command;
-	GPtrArray *params;
+	GPtrArray* tags;
+	gchar* source;
+	gchar* command;
+	GPtrArray* params;
 };
 
 G_DEFINE_TYPE (IrciumMessage, ircium_message, G_TYPE_OBJECT)
 
-static IrciumMessage *
+static IrciumMessage*
 ircium_message_new_real (void)
 {
 	return g_object_new (IRCIUM_TYPE_MESSAGE, NULL);
 }
 
-IrciumMessage *
-ircium_message_new (GPtrArray *tags,
-                    gchar     *source,
-                    gchar     *cmd,
-                    GPtrArray *params)
+IrciumMessage*
+ircium_message_new (GPtrArray* tags,
+                    gchar* source,
+                    gchar* cmd,
+                    GPtrArray* params)
 {
-	IrciumMessage *ret = ircium_message_new_real ();
+	IrciumMessage* ret = ircium_message_new_real ();
 	ret->tags = tags != NULL ? g_ptr_array_ref (tags) : NULL;
 	ret->source = g_strdup (source);
 	ret->command = g_strdup (cmd);
@@ -54,9 +54,9 @@ ircium_message_new (GPtrArray *tags,
 }
 
 static void
-ircium_message_finalize (GObject *object)
+ircium_message_finalize (GObject* object)
 {
-	IrciumMessage *self = (IrciumMessage *)object;
+	IrciumMessage* self = (IrciumMessage*)object;
 
 	g_clear_pointer (&self->tags, g_ptr_array_unref);
 	g_clear_pointer (&self->source, g_free);
@@ -67,63 +67,59 @@ ircium_message_finalize (GObject *object)
 }
 
 static void
-ircium_message_class_init (IrciumMessageClass *klass)
+ircium_message_class_init (IrciumMessageClass* klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	GObjectClass* object_class = G_OBJECT_CLASS (klass);
 
 	object_class->finalize = ircium_message_finalize;
 }
 
 static void
-ircium_message_init (IrciumMessage *self)
-{
-}
+ircium_message_init (IrciumMessage* self)
+{}
 
 static gboolean
-legal_tag_char (gchar c) {
+legal_tag_char (gchar c)
+{
 	return c != ' ' && c != '\r' && c != '\0' && c != '\n';
 }
 
-gchar *
-get_string_between (const guint8 *start,
-                    const guint8 *end)
+gchar*
+get_string_between (const guint8* start, const guint8* end)
 {
 	ptrdiff_t diff = end - start;
-	gchar *ret = g_malloc0 (diff + 1);
+	gchar* ret = g_malloc0 (diff + 1);
 
 	memcpy (ret, start, diff);
 
 	return ret;
 }
 
-static IrciumMessageTag *
-new_tag_named (const guint8 *head,
-               const guint8 *iter)
+static IrciumMessageTag*
+new_tag_named (const guint8* head, const guint8* iter)
 {
-	gchar *tag_name = get_string_between (head, iter);
-	IrciumMessageTag *tag = ircium_message_tag_new_with_name (tag_name);
+	gchar* tag_name = get_string_between (head, iter);
+	IrciumMessageTag* tag = ircium_message_tag_new_with_name (tag_name);
 	g_free (tag_name);
 	return tag;
 }
 
-static gchar *
-tag_val (const guint8 *head,
-	 const guint8 *iter)
+static gchar*
+tag_val (const guint8* head, const guint8* iter)
 {
-	gchar *temp = get_string_between (head, iter);
-	gchar *ret = ircium_message_tag_unescape_string (temp);
+	gchar* temp = get_string_between (head, iter);
+	gchar* ret = ircium_message_tag_unescape_string (temp);
 	g_free (temp);
 	return ret;
 }
 
-IrciumMessage *
-ircium_message_parse (GByteArray *bytes,
-                      gboolean    has_tag_cap)
+IrciumMessage*
+ircium_message_parse (GByteArray* bytes, gboolean has_tag_cap)
 {
-	IrciumMessage *msg = NULL;
+	IrciumMessage* msg = NULL;
 
-	GPtrArray *tags = NULL;
-	const guint8 *iter = bytes->data;
+	GPtrArray* tags = NULL;
+	const guint8* iter = bytes->data;
 	if (has_tag_cap) {
 		// If we understand tags, like if we have
 		// enabled IRCv3.3 message-tags, or explicitly
@@ -139,20 +135,17 @@ ircium_message_parse (GByteArray *bytes,
 			// so we can look at this stuff a bit more.
 			tags = g_ptr_array_new_with_free_func (g_object_unref);
 			gboolean is_tag_name = TRUE;
-			const guint8 *head = ++iter;
-			IrciumMessageTag *tag = NULL;
+			const guint8* head = ++iter;
+			IrciumMessageTag* tag = NULL;
 			for (gchar c = *iter; legal_tag_char (c); c = *++iter) {
 				if (c == ';') {
 					// We have a tag seperator.
 					if (is_tag_name) {
-						tag = new_tag_named (head,
-								     iter);
+						tag = new_tag_named (head, iter);
 						g_ptr_array_add (tags, tag);
 					} else {
-						gchar *val = tag_val (head,
-								      iter);
-						ircium_message_tag_set_value
-							(tag, val);
+						gchar* val = tag_val (head, iter);
+						ircium_message_tag_set_value (tag, val);
 						g_free (val);
 					}
 					is_tag_name = TRUE;
@@ -190,17 +183,15 @@ ircium_message_parse (GByteArray *bytes,
 				goto clean_tags;
 			}
 			if (is_tag_name) {
-				tag = new_tag_named (head,
-						     iter);
+				tag = new_tag_named (head, iter);
 				g_ptr_array_add (tags, tag);
 			} else {
-				gchar *val = tag_val (head,
-						      iter);
-				ircium_message_tag_set_value
-					(tag, val);
+				gchar* val = tag_val (head, iter);
+				ircium_message_tag_set_value (tag, val);
 				g_free (val);
 			}
-			while (*++iter == ' ');
+			while (*++iter == ' ')
+				;
 		}
 	} else if (*iter == '@') {
 		// We have a tag (probably) but we don't have the capability
@@ -209,34 +200,37 @@ ircium_message_parse (GByteArray *bytes,
 	}
 
 	// Now we'll look for source, if such exists in this message.
-	gchar *source = NULL;
+	gchar* source = NULL;
 	if (*iter == ':') {
-		const guint8 *head = ++iter;
-		for (; *iter != ' '; ++iter);
+		const guint8* head = ++iter;
+		for (; *iter != ' '; ++iter)
+			;
 		// We now have our source.
 		source = get_string_between (head, iter);
 
-		while (*++iter == ' ');
+		while (*++iter == ' ')
+			;
 	}
 
 	// Now we're going to be parsing our command. This may either be
 	// a numeric or a command.
-	gchar *command = NULL;
+	gchar* command = NULL;
 	{
-		const guint8 *head = iter;
-		while (*++iter != ' ');
+		const guint8* head = iter;
+		while (*++iter != ' ')
+			;
 		command = get_string_between (head, iter);
 
-		while (*++iter == ' ');
+		while (*++iter == ' ')
+			;
 	}
 
-	GPtrArray *params = g_ptr_array_new_with_free_func (g_free);
+	GPtrArray* params = g_ptr_array_new_with_free_func (g_free);
 	{
-		const guint8 *head = iter;
+		const guint8* head = iter;
 		gboolean is_trailing_param = FALSE;
-		for (;*iter != '\r' && *(iter + 1) != '\n'; ++iter) {
-			if (*iter == ':' && !is_trailing_param &&
-			    *(iter - 1) == ' ') {
+		for (; *iter != '\r' && *(iter + 1) != '\n'; ++iter) {
+			if (*iter == ':' && !is_trailing_param && *(iter - 1) == ' ') {
 				is_trailing_param = TRUE;
 				head = iter + 1;
 				continue;
@@ -251,7 +245,7 @@ ircium_message_parse (GByteArray *bytes,
 				}
 				// We have something to actually make into
 				// a parameter.
-				gchar *param = get_string_between (head, iter);
+				gchar* param = get_string_between (head, iter);
 				g_ptr_array_add (params, param);
 				head = iter + 1;
 			}
@@ -262,7 +256,7 @@ ircium_message_parse (GByteArray *bytes,
 		if (head == iter && !is_trailing_param) {
 			g_clear_pointer (&params, g_ptr_array_unref);
 		} else {
-			gchar *param = get_string_between (head, iter);
+			gchar* param = get_string_between (head, iter);
 			g_ptr_array_add (params, param);
 		}
 	}
@@ -283,115 +277,101 @@ ret:
 	return msg;
 }
 
-const GPtrArray *
-ircium_message_get_tags (IrciumMessage *msg)
+const GPtrArray*
+ircium_message_get_tags (IrciumMessage* msg)
 {
 	return msg->tags;
 }
 
-const gchar *
-ircium_message_get_source (IrciumMessage *msg)
+const gchar*
+ircium_message_get_source (IrciumMessage* msg)
 {
 	return msg->source;
 }
 
-const gchar *
-ircium_message_get_command (IrciumMessage *msg)
+const gchar*
+ircium_message_get_command (IrciumMessage* msg)
 {
 	return msg->command;
 }
 
-const GPtrArray *
-ircium_message_get_params (IrciumMessage *msg)
+const GPtrArray*
+ircium_message_get_params (IrciumMessage* msg)
 {
 	return msg->params;
 }
 
-GBytes *
-ircium_message_serialize (IrciumMessage *msg)
+GBytes*
+ircium_message_serialize (IrciumMessage* msg)
 {
 	g_return_val_if_fail (IRCIUM_IS_MESSAGE (msg), NULL);
 
 	// First, we serialize the tags if we have any.
-	gchar *serialized_tags = NULL;
+	gchar* serialized_tags = NULL;
 	if (msg->tags != NULL) {
 		serialized_tags = g_strdup ("@");
 		gchar delimiter = ';';
 		for (gsize i = 0; i < msg->tags->len; ++i) {
-			IrciumMessageTag *tag = msg->tags->pdata[i];
-			if (i == msg->tags->len - 1) delimiter = ' ';
-			gchar *old_str = serialized_tags;
-			const gchar *name = ircium_message_tag_get_name (tag);
+			IrciumMessageTag* tag = msg->tags->pdata[i];
+			if (i == msg->tags->len - 1)
+				delimiter = ' ';
+			gchar* old_str = serialized_tags;
+			const gchar* name = ircium_message_tag_get_name (tag);
 			if (ircium_message_tag_has_value (tag)) {
-				const gchar *val =
-					ircium_message_tag_get_value (tag);
-				gchar *escaped_val =
-					ircium_message_tag_escape_string (val);
-				serialized_tags =
-					g_strdup_printf ("%s%s=%s%c",
-							 serialized_tags,
-							 name,
-							 escaped_val,
-							 delimiter);
+				const gchar* val = ircium_message_tag_get_value (tag);
+				gchar* escaped_val = ircium_message_tag_escape_string (val);
+				serialized_tags = g_strdup_printf (
+				  "%s%s=%s%c", serialized_tags, name, escaped_val, delimiter);
 				g_free (escaped_val);
 			} else {
 				serialized_tags =
-					g_strdup_printf ("%s%s%c",
-							 serialized_tags,
-							 name,
-							 delimiter);
+				  g_strdup_printf ("%s%s%c", serialized_tags, name, delimiter);
 			}
 			g_free (old_str);
 		}
 	}
 
 	// Now, we'll serialize the source, if we have any.
-	gchar *serialized_source = NULL;
+	gchar* serialized_source = NULL;
 	if (msg->source != NULL) {
 		serialized_source = g_strdup_printf (":%s ", msg->source);
 	}
 
 	// Now the command.
-	gchar *serialized_command = g_strdup (msg->command);
+	gchar* serialized_command = g_strdup (msg->command);
 
 	// And the parameters if we have any.
-	gchar *serialized_params = NULL;
+	gchar* serialized_params = NULL;
 	if (msg->params != NULL) {
 		serialized_params = g_strdup (" ");
 		gboolean is_trailing = FALSE;
 		for (gsize i = 0; i < msg->params->len; ++i) {
-			gchar *param = msg->params->pdata[i];
-			if (i == msg->params->len - 1) is_trailing = TRUE;
-			gchar *old_str = serialized_params;
-			gchar *tmp = serialized_params == NULL ?
-				"" : serialized_params;
+			gchar* param = msg->params->pdata[i];
+			if (i == msg->params->len - 1)
+				is_trailing = TRUE;
+			gchar* old_str = serialized_params;
+			gchar* tmp = serialized_params == NULL ? "" : serialized_params;
 			if (is_trailing) {
-				serialized_params =
-					g_strdup_printf ("%s:%s",
-							 tmp,
-							 param);
+				serialized_params = g_strdup_printf ("%s:%s", tmp, param);
 			} else {
-				serialized_params =
-					g_strdup_printf ("%s%s ",
-							 tmp,
-							 param);
+				serialized_params = g_strdup_printf ("%s%s ", tmp, param);
 			}
 			g_free (old_str);
 		}
 	}
 
-	gchar *serialized_msg =
-		g_strdup_printf ("%s%s%s%s\r\n",
-				 serialized_tags ? serialized_tags : "",
-				 serialized_source ? serialized_source : "",
-				 serialized_command,
-				 serialized_params ? serialized_params : "");
+	gchar* serialized_msg =
+	  g_strdup_printf ("%s%s%s%s\r\n",
+	                   serialized_tags ? serialized_tags : "",
+	                   serialized_source ? serialized_source : "",
+	                   serialized_command,
+	                   serialized_params ? serialized_params : "");
 
 	// We really don't care about the NUL byte anyhow,
 	// because this will be sent across the wire.
 	gsize len = strlen (serialized_msg);
 
-	GBytes *bytes = g_bytes_new_take (serialized_msg, len);
+	GBytes* bytes = g_bytes_new_take (serialized_msg, len);
 
 	g_clear_pointer (&serialized_tags, g_free);
 	g_clear_pointer (&serialized_source, g_free);

--- a/lib/irc-parser/ircium-message.h
+++ b/lib/irc-parser/ircium-message.h
@@ -32,25 +32,25 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (IrciumMessage, ircium_message, IRCIUM, MESSAGE, GObject)
 
 IrciumMessage*
-ircium_message_parse (GByteArray* bytes, gboolean has_tag_cap);
+ircium_message_parse (const GByteArray* bytes, const gboolean has_tag_cap);
 
 IrciumMessage*
 ircium_message_new (GPtrArray* tags,
-                    gchar* source,
-                    gchar* cmd,
+                    const gchar* source,
+                    const gchar* cmd,
                     GPtrArray* params);
 
 const GPtrArray*
-ircium_message_get_tags (IrciumMessage* msg);
+ircium_message_get_tags (const IrciumMessage* msg);
 const gchar*
-ircium_message_get_source (IrciumMessage* msg);
+ircium_message_get_source (const IrciumMessage* msg);
 const gchar*
-ircium_message_get_command (IrciumMessage* msg);
+ircium_message_get_command (const IrciumMessage* msg);
 const GPtrArray*
-ircium_message_get_params (IrciumMessage* msg);
+ircium_message_get_params (const IrciumMessage* msg);
 
 GBytes*
-ircium_message_serialize (IrciumMessage* msg);
+ircium_message_serialize (const IrciumMessage* msg);
 
 gchar*
 get_string_between (const guint8* start, const guint8* end);

--- a/lib/irc-parser/ircium-message.h
+++ b/lib/irc-parser/ircium-message.h
@@ -27,28 +27,32 @@
 
 G_BEGIN_DECLS
 
-#define IRCIUM_TYPE_MESSAGE (ircium_message_get_type())
+#define IRCIUM_TYPE_MESSAGE (ircium_message_get_type ())
 
-G_DECLARE_FINAL_TYPE (IrciumMessage,
-		      ircium_message,
-		      IRCIUM, MESSAGE,
-		      GObject)
+G_DECLARE_FINAL_TYPE (IrciumMessage, ircium_message, IRCIUM, MESSAGE, GObject)
 
-IrciumMessage *ircium_message_parse (GByteArray *bytes,
-                                     gboolean    has_tag_cap);
+IrciumMessage*
+ircium_message_parse (GByteArray* bytes, gboolean has_tag_cap);
 
-IrciumMessage *ircium_message_new (GPtrArray *tags,
-                                   gchar     *source,
-                                   gchar     *cmd,
-                                   GPtrArray *params);
+IrciumMessage*
+ircium_message_new (GPtrArray* tags,
+                    gchar* source,
+                    gchar* cmd,
+                    GPtrArray* params);
 
-const GPtrArray *ircium_message_get_tags (IrciumMessage *msg);
-const gchar *ircium_message_get_source (IrciumMessage *msg);
-const gchar *ircium_message_get_command (IrciumMessage *msg);
-const GPtrArray *ircium_message_get_params (IrciumMessage *msg);
+const GPtrArray*
+ircium_message_get_tags (IrciumMessage* msg);
+const gchar*
+ircium_message_get_source (IrciumMessage* msg);
+const gchar*
+ircium_message_get_command (IrciumMessage* msg);
+const GPtrArray*
+ircium_message_get_params (IrciumMessage* msg);
 
-GBytes *ircium_message_serialize (IrciumMessage *msg);
+GBytes*
+ircium_message_serialize (IrciumMessage* msg);
 
-gchar *get_string_between (const guint8 *start, const guint8 *end);
+gchar*
+get_string_between (const guint8* start, const guint8* end);
 
 G_END_DECLS

--- a/lib/irc/core_hooks.c
+++ b/lib/irc/core_hooks.c
@@ -178,5 +178,5 @@ register_core_hooks ()
 	add_hook ("PREINIT", register_preinit_hook);
 	add_hook ("INVITE", invite_hook);
 	add_hook ("PING", ping_hook);
-	// add_hook ("001", channel_join_hook);
+	add_hook ("001", channel_join_hook);
 }

--- a/lib/irc/core_hooks.c
+++ b/lib/irc/core_hooks.c
@@ -7,7 +7,7 @@
 #include "hooks.h"
 
 static void
-register_preinit_hook (const irc_server* s, IrciumMessage* msg)
+register_preinit_hook (const irc_server* s, const IrciumMessage* msg)
 {
 	char* nick = getenv ("CIRC_NICK");
 	char* ident = getenv ("CIRC_IDENT");
@@ -18,7 +18,7 @@ register_preinit_hook (const irc_server* s, IrciumMessage* msg)
 	/* Sends NICK */
 	GPtrArray* nick_params = g_ptr_array_new_full (1, g_free);
 	g_ptr_array_add (nick_params, g_strdup (nick));
-	IrciumMessage* nick_cmd =
+	const IrciumMessage* nick_cmd =
 	  ircium_message_new (NULL, NULL, "NICK", nick_params);
 	if (irc_write_message (s, nick_cmd) == -1) {
 		perror ("client: nick_cmd");
@@ -33,7 +33,7 @@ register_preinit_hook (const irc_server* s, IrciumMessage* msg)
 	g_ptr_array_add (user_params, g_strdup ("0"));
 	g_ptr_array_add (user_params, g_strdup ("*"));
 	g_ptr_array_add (user_params, g_strdup (realname));
-	IrciumMessage* user_cmd =
+	const IrciumMessage* user_cmd =
 	  ircium_message_new (NULL, NULL, "USER", user_params);
 	if (irc_write_message (s, user_cmd) == -1) {
 		perror ("client: user_cmd");
@@ -42,26 +42,26 @@ register_preinit_hook (const irc_server* s, IrciumMessage* msg)
 }
 
 static void
-sasl_preinit_hook (const irc_server* s, IrciumMessage* msg)
+sasl_preinit_hook (const irc_server* s, const IrciumMessage* msg)
 {
 	log_info ("Doing SASL Auth\n");
 	GPtrArray* cap_params = g_ptr_array_new_full (2, g_free);
 	g_ptr_array_add (cap_params, g_strdup ("REQ"));
 	g_ptr_array_add (cap_params, g_strdup ("sasl"));
-	IrciumMessage* cap_cmd = ircium_message_new (NULL, NULL, "CAP", cap_params);
+	const IrciumMessage* cap_cmd = ircium_message_new (NULL, NULL, "CAP", cap_params);
 	irc_write_message (s, cap_cmd);
 	g_free (g_ptr_array_free (cap_params, TRUE));
 
 	GPtrArray* auth_params = g_ptr_array_new_full (1, g_free);
 	g_ptr_array_add (auth_params, g_strdup ("PLAIN"));
-	IrciumMessage* auth_cmd =
+	const IrciumMessage* auth_cmd =
 	  ircium_message_new (NULL, NULL, "AUTHENTICATE", auth_params);
 	irc_write_message (s, auth_cmd);
 	g_free (g_ptr_array_free (auth_params, TRUE));
 }
 
 static void
-sasl_auth_hook (const irc_server* s, IrciumMessage* msg)
+sasl_auth_hook (const irc_server* s, const IrciumMessage* msg)
 {
 	/* When we receive "AUTHENTICATE +" we can send our user data
 	 */
@@ -80,7 +80,7 @@ sasl_auth_hook (const irc_server* s, IrciumMessage* msg)
 
 	GPtrArray* pass_params = g_ptr_array_new_full (1, g_free);
 	g_ptr_array_add (pass_params, auth_string_encoded);
-	IrciumMessage* pass_cmd =
+	const IrciumMessage* pass_cmd =
 	  ircium_message_new (NULL, NULL, "AUTHENTICATE", pass_params);
 
 	int ret = irc_write_message (s, pass_cmd);
@@ -93,27 +93,27 @@ sasl_auth_hook (const irc_server* s, IrciumMessage* msg)
 }
 
 static void
-sasl_cap_hook (const irc_server* s, IrciumMessage* msg)
+sasl_cap_hook (const irc_server* s, const IrciumMessage* msg)
 {
 	/* Once we receive the 903 command we know the auth was successful.
 	 * to proceed we need to end the CAP phase
 	 */
 	GPtrArray* pass_params = g_ptr_array_new_full (1, g_free);
 	g_ptr_array_add (pass_params, "END");
-	IrciumMessage* pass_cmd =
+	const IrciumMessage* pass_cmd =
 	  ircium_message_new (NULL, NULL, "CAP", pass_params);
 
 	irc_write_message (s, pass_cmd);
 }
 
 static void
-sasl_error_hook (const irc_server* s, IrciumMessage* msg)
+sasl_error_hook (const irc_server* s, const IrciumMessage* msg)
 {
 	err (1, "Error during SASL Auth");
 }
 
 static void
-channel_join_hook (const irc_server* s, IrciumMessage* msg)
+channel_join_hook (const irc_server* s, const IrciumMessage* msg)
 {
 	/* If we encounter either the first MODE message or a WELCOME (001)
 	 * message we know we are auth'ed and can exit the init loop.
@@ -126,13 +126,13 @@ channel_join_hook (const irc_server* s, IrciumMessage* msg)
 
 	GPtrArray* join_params = g_ptr_array_new_full (1, g_free);
 	g_ptr_array_add (join_params, channel);
-	IrciumMessage* join_cmd =
+	const IrciumMessage* join_cmd =
 	  ircium_message_new (NULL, NULL, "JOIN", join_params);
 	irc_write_message (s, join_cmd);
 }
 
 static void
-ping_hook (const irc_server* s, IrciumMessage* msg)
+ping_hook (const irc_server* s, const IrciumMessage* msg)
 {
 	const GPtrArray* msg_params = ircium_message_get_params (msg);
 
@@ -141,7 +141,7 @@ ping_hook (const irc_server* s, IrciumMessage* msg)
 	GPtrArray* msg_params_nonconst = g_ptr_array_new_full (1, g_free);
 	g_ptr_array_add (msg_params_nonconst, msg_params->pdata[0]);
 
-	IrciumMessage* pong_cmd =
+	const IrciumMessage* pong_cmd =
 	  ircium_message_new (NULL, NULL, "PONG", msg_params_nonconst);
 	irc_write_message (s, pong_cmd);
 
@@ -149,13 +149,13 @@ ping_hook (const irc_server* s, IrciumMessage* msg)
 }
 
 static void
-invite_hook (const irc_server* s, IrciumMessage* msg)
+invite_hook (const irc_server* s, const IrciumMessage* msg)
 {
 	const GPtrArray* ircium_params = ircium_message_get_params (msg);
 	GPtrArray* msg_params = g_ptr_array_new_full (ircium_params->len, g_free);
 	g_ptr_array_add (msg_params, ircium_params->pdata[1]);
 
-	IrciumMessage* join_cmd =
+	const IrciumMessage* join_cmd =
 	  ircium_message_new (NULL, NULL, "JOIN", msg_params);
 	irc_write_message (s, join_cmd);
 	g_ptr_array_free (msg_params, TRUE);

--- a/lib/irc/core_hooks.c
+++ b/lib/irc/core_hooks.c
@@ -2,18 +2,18 @@
 #include <glib.h>
 #include <stdio.h>
 
-#include "hooks.h"
-#include "../log/log.h"
 #include "../b64/b64.h"
+#include "../log/log.h"
+#include "hooks.h"
 
 static void
-register_preinit_hook (const irc_server *s, IrciumMessage *msg)
+register_preinit_hook (const irc_server* s, IrciumMessage* msg)
 {
 	char* nick = getenv ("CIRC_NICK");
 	char* ident = getenv ("CIRC_IDENT");
 	char* realname = getenv ("CIRC_REALNAME");
 
-	puts("Registering client...");
+	puts ("Registering client...");
 
 	/* Sends NICK */
 	GPtrArray* nick_params = g_ptr_array_new_full (1, g_free);
@@ -42,14 +42,13 @@ register_preinit_hook (const irc_server *s, IrciumMessage *msg)
 }
 
 static void
-sasl_preinit_hook (const irc_server *s, IrciumMessage *msg)
+sasl_preinit_hook (const irc_server* s, IrciumMessage* msg)
 {
 	log_info ("Doing SASL Auth\n");
 	GPtrArray* cap_params = g_ptr_array_new_full (2, g_free);
 	g_ptr_array_add (cap_params, g_strdup ("REQ"));
 	g_ptr_array_add (cap_params, g_strdup ("sasl"));
-	IrciumMessage* cap_cmd =
-	  ircium_message_new (NULL, NULL, "CAP", cap_params);
+	IrciumMessage* cap_cmd = ircium_message_new (NULL, NULL, "CAP", cap_params);
 	irc_write_message (s, cap_cmd);
 	g_free (g_ptr_array_free (cap_params, TRUE));
 
@@ -62,10 +61,10 @@ sasl_preinit_hook (const irc_server *s, IrciumMessage *msg)
 }
 
 static void
-sasl_auth_hook (const irc_server *s, IrciumMessage *msg)
+sasl_auth_hook (const irc_server* s, IrciumMessage* msg)
 {
 	/* When we receive "AUTHENTICATE +" we can send our user data
- 	 */
+	 */
 	char* auth_user = getenv ("CIRC_AUTH_USER");
 	char* auth_pass = getenv ("CIRC_AUTH_PASS");
 
@@ -76,8 +75,8 @@ sasl_auth_hook (const irc_server *s, IrciumMessage *msg)
 	auth_string = g_strdup_printf (
 	  "%s%c%s%c%s", auth_user, nullchar, auth_user, nullchar, auth_pass);
 
-	char* auth_string_encoded = b64_encode (
-	  auth_string, strlen (auth_user) * 2 + strlen (auth_pass) + 2);
+	char* auth_string_encoded =
+	  b64_encode (auth_string, strlen (auth_user) * 2 + strlen (auth_pass) + 2);
 
 	GPtrArray* pass_params = g_ptr_array_new_full (1, g_free);
 	g_ptr_array_add (pass_params, auth_string_encoded);
@@ -94,7 +93,7 @@ sasl_auth_hook (const irc_server *s, IrciumMessage *msg)
 }
 
 static void
-sasl_cap_hook (const irc_server *s, IrciumMessage *msg)
+sasl_cap_hook (const irc_server* s, IrciumMessage* msg)
 {
 	/* Once we receive the 903 command we know the auth was successful.
 	 * to proceed we need to end the CAP phase
@@ -108,13 +107,13 @@ sasl_cap_hook (const irc_server *s, IrciumMessage *msg)
 }
 
 static void
-sasl_error_hook (const irc_server *s, IrciumMessage *msg)
+sasl_error_hook (const irc_server* s, IrciumMessage* msg)
 {
 	err (1, "Error during SASL Auth");
 }
 
 static void
-channel_join_hook (const irc_server *s, IrciumMessage *msg)
+channel_join_hook (const irc_server* s, IrciumMessage* msg)
 {
 	/* If we encounter either the first MODE message or a WELCOME (001)
 	 * message we know we are auth'ed and can exit the init loop.
@@ -123,7 +122,7 @@ channel_join_hook (const irc_server *s, IrciumMessage *msg)
 	char* channel = getenv ("CIRC_CHANNEL");
 	log_info ("channel: %s \n", channel);
 
-	puts("Joining channels");
+	puts ("Joining channels");
 
 	GPtrArray* join_params = g_ptr_array_new_full (1, g_free);
 	g_ptr_array_add (join_params, channel);
@@ -133,11 +132,12 @@ channel_join_hook (const irc_server *s, IrciumMessage *msg)
 }
 
 static void
-ping_hook (const irc_server *s, IrciumMessage *msg)
+ping_hook (const irc_server* s, IrciumMessage* msg)
 {
 	const GPtrArray* msg_params = ircium_message_get_params (msg);
 
-	/* Responds to PING request with the correct PONG so we don't get timeouted */
+	/* Responds to PING request with the correct PONG so we don't get timeouted
+	 */
 	GPtrArray* msg_params_nonconst = g_ptr_array_new_full (1, g_free);
 	g_ptr_array_add (msg_params_nonconst, msg_params->pdata[0]);
 
@@ -149,13 +149,14 @@ ping_hook (const irc_server *s, IrciumMessage *msg)
 }
 
 static void
-invite_hook (const irc_server *s, IrciumMessage *msg)
+invite_hook (const irc_server* s, IrciumMessage* msg)
 {
-	const GPtrArray *ircium_params = ircium_message_get_params (msg);
-	GPtrArray *msg_params = g_ptr_array_new_full (ircium_params->len, g_free);
+	const GPtrArray* ircium_params = ircium_message_get_params (msg);
+	GPtrArray* msg_params = g_ptr_array_new_full (ircium_params->len, g_free);
 	g_ptr_array_add (msg_params, ircium_params->pdata[1]);
-	
-	IrciumMessage *join_cmd = ircium_message_new (NULL, NULL, "JOIN", msg_params);
+
+	IrciumMessage* join_cmd =
+	  ircium_message_new (NULL, NULL, "JOIN", msg_params);
 	irc_write_message (s, join_cmd);
 	g_ptr_array_free (msg_params, TRUE);
 }
@@ -163,8 +164,8 @@ invite_hook (const irc_server *s, IrciumMessage *msg)
 void
 register_core_hooks ()
 {
-	char *sasl_str = getenv ("CIRC_SASL_ENABLED");
-	int sasl_enabled = sasl_str && strncmp(sasl_str, "true", 4) == 0;
+	char* sasl_str = getenv ("CIRC_SASL_ENABLED");
+	int sasl_enabled = sasl_str && strncmp (sasl_str, "true", 4) == 0;
 	/* Handle SASL */
 	if (sasl_enabled) {
 		add_hook ("PREINIT", sasl_preinit_hook);

--- a/lib/irc/core_hooks.c
+++ b/lib/irc/core_hooks.c
@@ -1,0 +1,181 @@
+#include <err.h>
+#include <glib.h>
+#include <stdio.h>
+
+#include "hooks.h"
+#include "../log/log.h"
+#include "../b64/b64.h"
+
+static void
+register_preinit_hook (const irc_server *s, IrciumMessage *msg)
+{
+	char* nick = getenv ("CIRC_NICK");
+	char* ident = getenv ("CIRC_IDENT");
+	char* realname = getenv ("CIRC_REALNAME");
+
+	puts("Registering client...");
+
+	/* Sends NICK */
+	GPtrArray* nick_params = g_ptr_array_new_full (1, g_free);
+	g_ptr_array_add (nick_params, g_strdup (nick));
+	IrciumMessage* nick_cmd =
+	  ircium_message_new (NULL, NULL, "NICK", nick_params);
+	if (irc_write_message (s, nick_cmd) == -1) {
+		perror ("client: nick_cmd");
+		exit (EXIT_FAILURE);
+	}
+
+	g_free (g_ptr_array_free (nick_params, TRUE));
+
+	/* Sends USER */
+	GPtrArray* user_params = g_ptr_array_new_full (4, g_free);
+	g_ptr_array_add (user_params, g_strdup (ident));
+	g_ptr_array_add (user_params, g_strdup ("0"));
+	g_ptr_array_add (user_params, g_strdup ("*"));
+	g_ptr_array_add (user_params, g_strdup (realname));
+	IrciumMessage* user_cmd =
+	  ircium_message_new (NULL, NULL, "USER", user_params);
+	if (irc_write_message (s, user_cmd) == -1) {
+		perror ("client: user_cmd");
+		exit (EXIT_FAILURE);
+	}
+}
+
+static void
+sasl_preinit_hook (const irc_server *s, IrciumMessage *msg)
+{
+	log_info ("Doing SASL Auth\n");
+	GPtrArray* cap_params = g_ptr_array_new_full (2, g_free);
+	g_ptr_array_add (cap_params, g_strdup ("REQ"));
+	g_ptr_array_add (cap_params, g_strdup ("sasl"));
+	IrciumMessage* cap_cmd =
+	  ircium_message_new (NULL, NULL, "CAP", cap_params);
+	irc_write_message (s, cap_cmd);
+	g_free (g_ptr_array_free (cap_params, TRUE));
+
+	GPtrArray* auth_params = g_ptr_array_new_full (1, g_free);
+	g_ptr_array_add (auth_params, g_strdup ("PLAIN"));
+	IrciumMessage* auth_cmd =
+	  ircium_message_new (NULL, NULL, "AUTHENTICATE", auth_params);
+	irc_write_message (s, auth_cmd);
+	g_free (g_ptr_array_free (auth_params, TRUE));
+}
+
+static void
+sasl_auth_hook (const irc_server *s, IrciumMessage *msg)
+{
+	/* When we receive "AUTHENTICATE +" we can send our user data
+ 	 */
+	char* auth_user = getenv ("CIRC_AUTH_USER");
+	char* auth_pass = getenv ("CIRC_AUTH_PASS");
+
+	log_info ("Doing SASL Auth\n");
+
+	gchar* auth_string;
+	char nullchar = '\0';
+	auth_string = g_strdup_printf (
+	  "%s%c%s%c%s", auth_user, nullchar, auth_user, nullchar, auth_pass);
+
+	char* auth_string_encoded = b64_encode (
+	  auth_string, strlen (auth_user) * 2 + strlen (auth_pass) + 2);
+
+	GPtrArray* pass_params = g_ptr_array_new_full (1, g_free);
+	g_ptr_array_add (pass_params, auth_string_encoded);
+	IrciumMessage* pass_cmd =
+	  ircium_message_new (NULL, NULL, "AUTHENTICATE", pass_params);
+
+	int ret = irc_write_message (s, pass_cmd);
+
+	g_free (g_ptr_array_free (pass_params, TRUE));
+	g_free (auth_string);
+	if (ret == -1) {
+		err (1, "Error during SASL Auth");
+	}
+}
+
+static void
+sasl_cap_hook (const irc_server *s, IrciumMessage *msg)
+{
+	/* Once we receive the 903 command we know the auth was successful.
+	 * to proceed we need to end the CAP phase
+	 */
+	GPtrArray* pass_params = g_ptr_array_new_full (1, g_free);
+	g_ptr_array_add (pass_params, "END");
+	IrciumMessage* pass_cmd =
+	  ircium_message_new (NULL, NULL, "CAP", pass_params);
+
+	irc_write_message (s, pass_cmd);
+}
+
+static void
+sasl_error_hook (const irc_server *s, IrciumMessage *msg)
+{
+	err (1, "Error during SASL Auth");
+}
+
+static void
+channel_join_hook (const irc_server *s, IrciumMessage *msg)
+{
+	/* If we encounter either the first MODE message or a WELCOME (001)
+	 * message we know we are auth'ed and can exit the init loop.
+	 * Before that we JOIN the Channels
+	 */
+	char* channel = getenv ("CIRC_CHANNEL");
+	log_info ("channel: %s \n", channel);
+
+	puts("Joining channels");
+
+	GPtrArray* join_params = g_ptr_array_new_full (1, g_free);
+	g_ptr_array_add (join_params, channel);
+	IrciumMessage* join_cmd =
+	  ircium_message_new (NULL, NULL, "JOIN", join_params);
+	irc_write_message (s, join_cmd);
+}
+
+static void
+ping_hook (const irc_server *s, IrciumMessage *msg)
+{
+	const GPtrArray* msg_params = ircium_message_get_params (msg);
+
+	/* Responds to PING request with the correct PONG so we don't get timeouted */
+	GPtrArray* msg_params_nonconst = g_ptr_array_new_full (1, g_free);
+	g_ptr_array_add (msg_params_nonconst, msg_params->pdata[0]);
+
+	IrciumMessage* pong_cmd =
+	  ircium_message_new (NULL, NULL, "PONG", msg_params_nonconst);
+	irc_write_message (s, pong_cmd);
+
+	g_free (g_ptr_array_free (msg_params_nonconst, TRUE));
+}
+
+static void
+invite_hook (const irc_server *s, IrciumMessage *msg)
+{
+	const GPtrArray *ircium_params = ircium_message_get_params (msg);
+	GPtrArray *msg_params = g_ptr_array_new_full (ircium_params->len, g_free);
+	g_ptr_array_add (msg_params, ircium_params->pdata[1]);
+	
+	IrciumMessage *join_cmd = ircium_message_new (NULL, NULL, "JOIN", msg_params);
+	irc_write_message (s, join_cmd);
+	g_ptr_array_free (msg_params, TRUE);
+}
+
+void
+register_core_hooks ()
+{
+	char *sasl_str = getenv ("CIRC_SASL_ENABLED");
+	int sasl_enabled = sasl_str && strncmp(sasl_str, "true", 4) == 0;
+	/* Handle SASL */
+	if (sasl_enabled) {
+		add_hook ("PREINIT", sasl_preinit_hook);
+		add_hook ("AUTHENTICATE", sasl_auth_hook);
+		add_hook ("900", sasl_cap_hook);
+		add_hook ("903", sasl_cap_hook);
+		add_hook ("904", sasl_error_hook);
+	}
+
+	add_hook ("PREINIT", register_preinit_hook);
+	add_hook ("INVITE", invite_hook);
+	add_hook ("PING", ping_hook);
+	// add_hook ("001", channel_join_hook);
+}

--- a/lib/irc/hooks.c
+++ b/lib/irc/hooks.c
@@ -97,7 +97,7 @@ exec_hooks (const irc_server *s, IrciumMessage *msg)
 	if (msg == NULL)
 		command = "PREINIT";
 	else
-		ircium_message_get_command(msg);
+		command = ircium_message_get_command(msg);
 
 	for (hook = get_hooks (command); hook != NULL; hook = hook->next)
 		hook->entry(s, msg);

--- a/lib/irc/hooks.c
+++ b/lib/irc/hooks.c
@@ -96,6 +96,8 @@ exec_hooks (const irc_server *s, IrciumMessage *msg)
 	const char *command;
 	if (msg == NULL)
 		command = "PREINIT";
+	else if (msg == (void *)1)
+		command = "*";
 	else
 		command = ircium_message_get_command(msg);
 

--- a/lib/irc/hooks.c
+++ b/lib/irc/hooks.c
@@ -11,7 +11,7 @@ void
 free_irc_hook (irc_hook* hook);
 irc_hook*
 create_irc_hook (const char* command,
-                 void (*f) (const irc_server*, IrciumMessage*));
+                 void (*f) (const irc_server*, const IrciumMessage*));
 static irc_hook*
 get_hooks_private (const char* command);
 static gboolean
@@ -53,7 +53,7 @@ free_irc_hook (irc_hook* hook)
 
 irc_hook*
 create_irc_hook (const char* command,
-                 void (*f) (const irc_server*, IrciumMessage*))
+                 void (*f) (const irc_server*, const IrciumMessage*))
 {
 	irc_hook* hook = malloc (sizeof (irc_hook));
 	hook->command = strdup (command);
@@ -64,7 +64,7 @@ create_irc_hook (const char* command,
 }
 
 void
-add_hook (const char* command, void (*f) (const irc_server*, IrciumMessage*))
+add_hook (const char* command, void (*f) (const irc_server*, const IrciumMessage*))
 {
 	irc_hook* hook = create_irc_hook (command, f);
 	irc_hook* head = get_hooks_private (command);
@@ -92,7 +92,7 @@ get_hooks (const char* command)
 }
 
 void
-exec_hooks (const irc_server* s, IrciumMessage* msg)
+exec_hooks (const irc_server* s, const IrciumMessage* msg)
 {
 	const irc_hook* hook;
 	const char* command;

--- a/lib/irc/hooks.c
+++ b/lib/irc/hooks.c
@@ -3,18 +3,19 @@
 
 #include "hooks.h"
 
-static GHashTable *hooks;
+static GHashTable* hooks;
 
 void
 g_free_irc_hook (gpointer hook);
 void
-free_irc_hook (irc_hook *hook);
-irc_hook *
-create_irc_hook (const char *command, void (*f) (const irc_server *, IrciumMessage *));
-static irc_hook *
-get_hooks_private (const char *command);
+free_irc_hook (irc_hook* hook);
+irc_hook*
+create_irc_hook (const char* command,
+                 void (*f) (const irc_server*, IrciumMessage*));
+static irc_hook*
+get_hooks_private (const char* command);
 static gboolean
-command_strings_equal(gconstpointer a, gconstpointer b);
+command_strings_equal (gconstpointer a, gconstpointer b);
 
 void
 init_hooks (void)
@@ -22,39 +23,40 @@ init_hooks (void)
 	if (hooks != NULL)
 		return;
 
-	hooks = g_hash_table_new_full(g_str_hash, command_strings_equal,
-			g_free, g_free_irc_hook);
+	hooks = g_hash_table_new_full (
+	  g_str_hash, command_strings_equal, g_free, g_free_irc_hook);
 }
 
 static gboolean
-command_strings_equal(gconstpointer a, gconstpointer b)
+command_strings_equal (gconstpointer a, gconstpointer b)
 {
-	return strcmp((const char *)a, (const char *)b) == 0;
+	return strcmp ((const char*)a, (const char*)b) == 0;
 }
 
 void
 g_free_irc_hook (gpointer hook)
 {
-	free_irc_hook ((irc_hook *)hook);
+	free_irc_hook ((irc_hook*)hook);
 }
 
 void
-free_irc_hook (irc_hook *hook)
+free_irc_hook (irc_hook* hook)
 {
-	irc_hook *tmp;
+	irc_hook* tmp;
 	while (hook != NULL) {
 		tmp = hook;
 		free (hook->command);
 		hook = hook->next;
-		free(tmp);
+		free (tmp);
 	}
 }
 
-irc_hook *
-create_irc_hook (const char *command, void (*f) (const irc_server *, IrciumMessage *))
+irc_hook*
+create_irc_hook (const char* command,
+                 void (*f) (const irc_server*, IrciumMessage*))
 {
-	irc_hook *hook = malloc (sizeof (irc_hook));
-	hook->command = strdup(command);
+	irc_hook* hook = malloc (sizeof (irc_hook));
+	hook->command = strdup (command);
 	hook->entry = f;
 	hook->next = NULL;
 
@@ -62,12 +64,12 @@ create_irc_hook (const char *command, void (*f) (const irc_server *, IrciumMessa
 }
 
 void
-add_hook (const char *command, void (*f) (const irc_server *, IrciumMessage *))
+add_hook (const char* command, void (*f) (const irc_server*, IrciumMessage*))
 {
-	irc_hook *hook = create_irc_hook (command, f);
-	irc_hook *head = get_hooks_private (command);
+	irc_hook* hook = create_irc_hook (command, f);
+	irc_hook* head = get_hooks_private (command);
 	if (head == NULL) {
-		g_hash_table_insert(hooks, hook->command, hook);
+		g_hash_table_insert (hooks, hook->command, hook);
 	} else if (head == NULL) {
 		head = hook;
 	} else {
@@ -77,30 +79,30 @@ add_hook (const char *command, void (*f) (const irc_server *, IrciumMessage *))
 	}
 }
 
-static irc_hook *
-get_hooks_private (const char *command)
+static irc_hook*
+get_hooks_private (const char* command)
 {
-	return (irc_hook *)g_hash_table_lookup(hooks, command);
+	return (irc_hook*)g_hash_table_lookup (hooks, command);
 }
 
-const irc_hook *
-get_hooks (const char *command)
+const irc_hook*
+get_hooks (const char* command)
 {
 	return get_hooks_private (command);
 }
 
 void
-exec_hooks (const irc_server *s, IrciumMessage *msg)
+exec_hooks (const irc_server* s, IrciumMessage* msg)
 {
-	const irc_hook *hook;
-	const char *command;
+	const irc_hook* hook;
+	const char* command;
 	if (msg == NULL)
 		command = "PREINIT";
-	else if (msg == (void *)1)
+	else if (msg == (void*)1)
 		command = "*";
 	else
-		command = ircium_message_get_command(msg);
+		command = ircium_message_get_command (msg);
 
 	for (hook = get_hooks (command); hook != NULL; hook = hook->next)
-		hook->entry(s, msg);
+		hook->entry (s, msg);
 }

--- a/lib/irc/hooks.c
+++ b/lib/irc/hooks.c
@@ -1,0 +1,86 @@
+#include <glib.h>
+#include "hooks.h"
+
+static GHashTable *hooks;
+
+void
+g_free_irc_hook (gpointer hook);
+void
+free_irc_hook (irc_hook *hook);
+irc_hook *
+create_irc_hook (char *command, circ_module *mod);
+static irc_hook *
+get_hooks_private (char *command);
+static gboolean
+command_strings_equal(gconstpointer a, gconstpointer b);
+
+void
+init_hooks (void)
+{
+	if (hooks != NULL)
+		return;
+
+	hooks = g_hash_table_new_full(g_str_hash, command_strings_equal,
+			g_free, g_free_irc_hook);
+}
+
+static gboolean
+command_strings_equal(gconstpointer a, gconstpointer b)
+{
+	return strcmp((const char *)a, (const char *)b) == 0;
+}
+
+void
+g_free_irc_hook (gpointer hook)
+{
+	free_irc_hook ((irc_hook *)hook);
+}
+
+void
+free_irc_hook (irc_hook *hook)
+{
+	irc_hook *tmp;
+	while (hook != NULL) {
+		tmp = hook;
+		free (hook->command);
+		hook = hook->next;
+		free(tmp);
+	}
+}
+
+irc_hook *
+create_irc_hook (char *command, circ_module *mod)
+{
+	irc_hook *hook = malloc (sizeof (irc_hook));
+	hook->command = strdup(command);
+	hook->mod = mod;
+	hook->next = NULL;
+
+	return hook;
+}
+
+void
+add_hook (char *command, circ_module *mod)
+{
+	irc_hook *hook = create_irc_hook (command, mod);
+	irc_hook *head = get_hooks_private (command);
+	if (hooks == NULL)
+		g_hash_table_insert(hooks, command, hook);
+	else {
+		while (head->next != NULL)
+			head = head->next;
+		head->next = hook;
+	}
+}
+
+static irc_hook *
+get_hooks_private (char *command)
+{
+	return (irc_hook *)g_hash_table_lookup(hooks, command);
+}
+
+const irc_hook *
+get_hooks (char *command)
+{
+	return get_hooks_private (command);
+}

--- a/lib/irc/hooks.c
+++ b/lib/irc/hooks.c
@@ -1,4 +1,6 @@
 #include <glib.h>
+#include <stdio.h>
+
 #include "hooks.h"
 
 static GHashTable *hooks;
@@ -8,9 +10,9 @@ g_free_irc_hook (gpointer hook);
 void
 free_irc_hook (irc_hook *hook);
 irc_hook *
-create_irc_hook (char *command, circ_module *mod);
+create_irc_hook (const char *command, void (*f) (const irc_server *, IrciumMessage *));
 static irc_hook *
-get_hooks_private (char *command);
+get_hooks_private (const char *command);
 static gboolean
 command_strings_equal(gconstpointer a, gconstpointer b);
 
@@ -49,24 +51,26 @@ free_irc_hook (irc_hook *hook)
 }
 
 irc_hook *
-create_irc_hook (char *command, circ_module *mod)
+create_irc_hook (const char *command, void (*f) (const irc_server *, IrciumMessage *))
 {
 	irc_hook *hook = malloc (sizeof (irc_hook));
 	hook->command = strdup(command);
-	hook->mod = mod;
+	hook->entry = f;
 	hook->next = NULL;
 
 	return hook;
 }
 
 void
-add_hook (char *command, circ_module *mod)
+add_hook (const char *command, void (*f) (const irc_server *, IrciumMessage *))
 {
-	irc_hook *hook = create_irc_hook (command, mod);
+	irc_hook *hook = create_irc_hook (command, f);
 	irc_hook *head = get_hooks_private (command);
-	if (hooks == NULL)
-		g_hash_table_insert(hooks, command, hook);
-	else {
+	if (head == NULL) {
+		g_hash_table_insert(hooks, hook->command, hook);
+	} else if (head == NULL) {
+		head = hook;
+	} else {
 		while (head->next != NULL)
 			head = head->next;
 		head->next = hook;
@@ -74,13 +78,27 @@ add_hook (char *command, circ_module *mod)
 }
 
 static irc_hook *
-get_hooks_private (char *command)
+get_hooks_private (const char *command)
 {
 	return (irc_hook *)g_hash_table_lookup(hooks, command);
 }
 
 const irc_hook *
-get_hooks (char *command)
+get_hooks (const char *command)
 {
 	return get_hooks_private (command);
+}
+
+void
+exec_hooks (const irc_server *s, IrciumMessage *msg)
+{
+	const irc_hook *hook;
+	const char *command;
+	if (msg == NULL)
+		command = "PREINIT";
+	else
+		ircium_message_get_command(msg);
+
+	for (hook = get_hooks (command); hook != NULL; hook = hook->next)
+		hook->entry(s, msg);
 }

--- a/lib/irc/hooks.c
+++ b/lib/irc/hooks.c
@@ -14,8 +14,6 @@ create_irc_hook (const char* command,
                  void (*f) (const irc_server*, const IrciumMessage*));
 static irc_hook*
 get_hooks_private (const char* command);
-static gboolean
-command_strings_equal (gconstpointer a, gconstpointer b);
 
 void
 init_hooks (void)
@@ -23,14 +21,8 @@ init_hooks (void)
 	if (hooks != NULL)
 		return;
 
-	hooks = g_hash_table_new_full (
-	  g_str_hash, command_strings_equal, g_free, g_free_irc_hook);
-}
-
-static gboolean
-command_strings_equal (gconstpointer a, gconstpointer b)
-{
-	return strcmp ((const char*)a, (const char*)b) == 0;
+	hooks =
+	  g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free_irc_hook);
 }
 
 void
@@ -64,7 +56,8 @@ create_irc_hook (const char* command,
 }
 
 void
-add_hook (const char* command, void (*f) (const irc_server*, const IrciumMessage*))
+add_hook (const char* command,
+          void (*f) (const irc_server*, const IrciumMessage*))
 {
 	irc_hook* hook = create_irc_hook (command, f);
 	irc_hook* head = get_hooks_private (command);

--- a/lib/irc/hooks.h
+++ b/lib/irc/hooks.h
@@ -4,15 +4,15 @@
 typedef struct irc_hook
 {
 	char* command;
-	void (*entry) (const irc_server*, IrciumMessage* msg);
+	void (*entry) (const irc_server*, const IrciumMessage* msg);
 	struct irc_hook* next;
 } irc_hook;
 
 void
 init_hooks (void);
 void
-add_hook (const char* command, void (*f) (const irc_server*, IrciumMessage*));
+add_hook (const char* command, void (*f) (const irc_server*, const IrciumMessage*));
 const irc_hook*
 get_hooks (const char* command);
 void
-exec_hooks (const irc_server* s, IrciumMessage* msg);
+exec_hooks (const irc_server* s, const IrciumMessage* msg);

--- a/lib/irc/hooks.h
+++ b/lib/irc/hooks.h
@@ -1,0 +1,14 @@
+#include "../modules/module.h"
+
+typedef struct irc_hook {
+	char *command;
+	circ_module *mod;
+	struct irc_hook *next;
+} irc_hook;
+
+void
+init_hooks (void);
+void
+add_hook (char *command, circ_module *mod);
+const irc_hook *
+get_hooks (char *command);

--- a/lib/irc/hooks.h
+++ b/lib/irc/hooks.h
@@ -1,17 +1,18 @@
 #include "irc-parser/ircium-message.h"
 #include "irc.h"
 
-typedef struct irc_hook {
-	char *command;
-	void (*entry) (const irc_server *, IrciumMessage *msg);
-	struct irc_hook *next;
+typedef struct irc_hook
+{
+	char* command;
+	void (*entry) (const irc_server*, IrciumMessage* msg);
+	struct irc_hook* next;
 } irc_hook;
 
 void
 init_hooks (void);
 void
-add_hook (const char *command, void (*f) (const irc_server *, IrciumMessage *));
-const irc_hook *
-get_hooks (const char *command);
+add_hook (const char* command, void (*f) (const irc_server*, IrciumMessage*));
+const irc_hook*
+get_hooks (const char* command);
 void
-exec_hooks (const irc_server *s, IrciumMessage *msg);
+exec_hooks (const irc_server* s, IrciumMessage* msg);

--- a/lib/irc/hooks.h
+++ b/lib/irc/hooks.h
@@ -1,14 +1,17 @@
-#include "../modules/module.h"
+#include "irc-parser/ircium-message.h"
+#include "irc.h"
 
 typedef struct irc_hook {
 	char *command;
-	circ_module *mod;
+	void (*entry) (const irc_server *, IrciumMessage *msg);
 	struct irc_hook *next;
 } irc_hook;
 
 void
 init_hooks (void);
 void
-add_hook (char *command, circ_module *mod);
+add_hook (const char *command, void (*f) (const irc_server *, IrciumMessage *));
 const irc_hook *
-get_hooks (char *command);
+get_hooks (const char *command);
+void
+exec_hooks (const irc_server *s, IrciumMessage *msg);

--- a/lib/irc/irc.c
+++ b/lib/irc/irc.c
@@ -250,7 +250,7 @@ handle_message (irc_connection* conn, const char* message)
 	while (gbuf == NULL)
 		gbuf = g_byte_array_new ();
 	gbuf = g_byte_array_append (gbuf, (guint8*)message, strlen (message));
-	IrciumMessage* parsed_message = ircium_message_parse (gbuf, false);
+	const IrciumMessage* parsed_message = ircium_message_parse (gbuf, false);
 	exec_hooks (conn->server, parsed_message);
 	exec_hooks (conn->server, (void*)1);
 }
@@ -300,7 +300,7 @@ irc_read_bytes (const irc_server* s, char* buf, size_t nbytes)
 
 /* Serialize an IrciumMessage and send it to the server */
 int
-irc_write_message (const irc_server* s, IrciumMessage* message)
+irc_write_message (const irc_server* s, const IrciumMessage* message)
 {
 	GBytes* bytes = ircium_message_serialize (message);
 

--- a/lib/irc/irc.c
+++ b/lib/irc/irc.c
@@ -242,14 +242,14 @@ irc_process_message_queue (irc_connection* conn)
 static void
 handle_message (irc_connection* conn, const char* message)
 {
-	GByteArray* gbuf;
+	GByteArray* gbuf = NULL;
 	size_t msg_len = strlen (message);
 	if (msg_len == 0)
 		return;
 
 	while (gbuf == NULL)
 		gbuf = g_byte_array_new ();
-	gbuf = g_byte_array_append (gbuf, (guint8*)message, strlen (message));
+	gbuf = g_byte_array_append (gbuf, (guint8*)message, msg_len);
 	const IrciumMessage* parsed_message = ircium_message_parse (gbuf, false);
 	exec_hooks (conn->server, parsed_message);
 	exec_hooks (conn->server, (void*)1);

--- a/lib/irc/irc.c
+++ b/lib/irc/irc.c
@@ -247,6 +247,7 @@ handle_message (irc_connection* conn, const char *message)
 	gbuf = g_byte_array_append (gbuf, (guint8* )message, strlen (message));
 	IrciumMessage* parsed_message = ircium_message_parse (gbuf, false);
 	exec_hooks(conn->server, parsed_message);
+	exec_hooks(conn->server, (void *)1);
 }
 
 /* irc_read_message reads an IRC message to a buffer */

--- a/lib/irc/irc.c
+++ b/lib/irc/irc.c
@@ -243,7 +243,12 @@ static void
 handle_message (irc_connection* conn, const char* message)
 {
 	GByteArray* gbuf;
-	gbuf = g_byte_array_new ();
+	size_t msg_len = strlen (message);
+	if (msg_len == 0)
+		return;
+
+	while (gbuf == NULL)
+		gbuf = g_byte_array_new ();
 	gbuf = g_byte_array_append (gbuf, (guint8*)message, strlen (message));
 	IrciumMessage* parsed_message = ircium_message_parse (gbuf, false);
 	exec_hooks (conn->server, parsed_message);

--- a/lib/irc/irc.h
+++ b/lib/irc/irc.h
@@ -10,6 +10,8 @@ typedef struct {
 	bool use_TLS;		// Whether to use TLS
 } irc_server;
 
+void register_core_hooks (void);
+
 int irc_server_connect (const irc_server *);
 void irc_do_event_loop (const irc_server *);
 void irc_do_init_event_loop (const irc_server *);

--- a/lib/irc/irc.h
+++ b/lib/irc/irc.h
@@ -1,23 +1,33 @@
-#include <stdbool.h>
-#include <glib.h>
 #include "irc-parser/ircium-message.h"
+#include <glib.h>
+#include <stdbool.h>
 
-typedef struct {
-	char *name;		// Server name
-	char *host;		// Server host
-	char *port;		// Connection port
-	char **channels;	// Joined channels (or to join)
-	bool use_TLS;		// Whether to use TLS
+typedef struct
+{
+	char* name;      // Server name
+	char* host;      // Server host
+	char* port;      // Connection port
+	char** channels; // Joined channels (or to join)
+	bool use_TLS;    // Whether to use TLS
 } irc_server;
 
-void register_core_hooks (void);
+void
+register_core_hooks (void);
 
-int irc_server_connect (const irc_server *);
-void irc_do_event_loop (const irc_server *);
-void irc_do_init_event_loop (const irc_server *);
-int irc_read_message (const irc_server *, char *);
-int irc_read_bytes (const irc_server *, char *, size_t);
-int irc_write_message (const irc_server *s, IrciumMessage *message);
-int irc_write_bytes (const irc_server *, guint8 *, size_t);
+int
+irc_server_connect (const irc_server*);
+void
+irc_do_event_loop (const irc_server*);
+void
+irc_do_init_event_loop (const irc_server*);
+int
+irc_read_message (const irc_server*, char*);
+int
+irc_read_bytes (const irc_server*, char*, size_t);
+int
+irc_write_message (const irc_server* s, IrciumMessage* message);
+int
+irc_write_bytes (const irc_server*, guint8*, size_t);
 
-void irc_init_channels (const irc_server *);
+void
+irc_init_channels (const irc_server*);

--- a/lib/irc/irc.h
+++ b/lib/irc/irc.h
@@ -25,7 +25,7 @@ irc_read_message (const irc_server*, char*);
 int
 irc_read_bytes (const irc_server*, char*, size_t);
 int
-irc_write_message (const irc_server* s, IrciumMessage* message);
+irc_write_message (const irc_server* s, const IrciumMessage* message);
 int
 irc_write_bytes (const irc_server*, guint8*, size_t);
 

--- a/lib/log/log.h
+++ b/lib/log/log.h
@@ -1,3 +1,5 @@
-void log_info (char* fmt, ...);
+void
+log_info (char* fmt, ...);
 
-void log_debug (char* fmt, ...);
+void
+log_debug (char* fmt, ...);

--- a/lib/modules/module.h
+++ b/lib/modules/module.h
@@ -1,1 +1,0 @@
-typedef struct circ_module { /* placeholder */ } circ_module;

--- a/lib/modules/module.h
+++ b/lib/modules/module.h
@@ -1,0 +1,1 @@
+typedef struct circ_module { /* placeholder */ } circ_module;

--- a/src/circ.c
+++ b/src/circ.c
@@ -34,12 +34,9 @@ main (int argc, char** argv)
 	char* realname = getenv ("CIRC_REALNAME");
 	char* sasl_enabled = getenv ("CIRC_SASL_ENABLED");
 
-
-
-
 	log_info ("setting up connection\n");
 	int ret = irc_server_connect (&s);
-	if (ret == -1) {
+	if (ret == -1 || errno) {
 		err (1, "Error Connecting");
 	}
 	log_info ("connection setup\n");

--- a/src/circ.c
+++ b/src/circ.c
@@ -16,7 +16,7 @@ int
 main (int argc, char** argv)
 {
 	bool is_secure;
-	char *is_secure_str = getenv ("CIRC_SSL");
+	char* is_secure_str = getenv ("CIRC_SSL");
 	if (is_secure_str != NULL && strncmp (is_secure_str, "true", 4) == 0) {
 		is_secure = true;
 	} else {
@@ -42,7 +42,7 @@ main (int argc, char** argv)
 	log_info ("connection setup\n");
 
 	// Calling exec_hooks with a NULL message executes the PREINIT hooks
-	exec_hooks(&s, NULL);
+	exec_hooks (&s, NULL);
 
 	/* Init Event Loop handels auth via sasl and breaks on
 	 * receiving either a MODE or WELCOME message.

--- a/src/circ.c
+++ b/src/circ.c
@@ -6,7 +6,7 @@
 #include <stdlib.h> // malloc
 
 #include "config/config.h"
-#include "irc/irc.h"
+#include "irc/hooks.h"
 #include "log/log.h"
 
 #include "b64/b64.h"
@@ -23,15 +23,15 @@ main (int argc, char** argv)
 		is_secure = false;
 	}
 
+	init_hooks ();
+	register_core_hooks ();
+
 	irc_server s = { getenv ("CIRC_SERVER_NAME"),
 		             getenv ("CIRC_SERVER_HOST"),
 		             getenv ("CIRC_SERVER_PORT"),
 		             NULL,
 		             is_secure };
 
-	char* nick = getenv ("CIRC_NICK");
-	char* ident = getenv ("CIRC_IDENT");
-	char* realname = getenv ("CIRC_REALNAME");
 	char* sasl_enabled = getenv ("CIRC_SASL_ENABLED");
 
 	log_info ("setting up connection\n");
@@ -41,63 +41,13 @@ main (int argc, char** argv)
 	}
 	log_info ("connection setup\n");
 
-	log_info ("sending nick/user info\n");
-
-    /* Sends NICK */
-	GPtrArray* nick_params = g_ptr_array_new_full (1, g_free);
-	g_ptr_array_add (nick_params, g_strdup (nick));
-	IrciumMessage* nick_cmd =
-	  ircium_message_new (NULL, NULL, "NICK", nick_params);
-    if (irc_write_message (&s, nick_cmd) == -1) {
-        perror ("client: nick_cmd");
-        exit (EXIT_FAILURE);
-    }
-
-	g_free (g_ptr_array_free (nick_params, TRUE));
-
-    /* Sends USER */
-	GPtrArray* user_params = g_ptr_array_new_full (4, g_free);
-	g_ptr_array_add (user_params, g_strdup (ident));
-	g_ptr_array_add (user_params, g_strdup ("0"));
-	g_ptr_array_add (user_params, g_strdup ("*"));
-	g_ptr_array_add (user_params, g_strdup (realname));
-	IrciumMessage* user_cmd =
-	  ircium_message_new (NULL, NULL, "USER", user_params);
-    if (irc_write_message (&s, user_cmd) == -1) {
-        perror ("client: user_cmd");
-        exit (EXIT_FAILURE);
-    }
-
-	g_free (g_ptr_array_free (user_params, TRUE));
-
-	log_info ("sent nick/user info\n");
-
-	/* If we want to do sasl auth we need to request
-	 * the sasl capability and initialize the plain auth process
-	 * after this the init event loop takes over doing the actual auth
-     */
-	if (sasl_enabled && strncmp(sasl_enabled, "true", 4) == 0) {
-		log_info ("Doing SASL Auth\n");
-		GPtrArray* cap_params = g_ptr_array_new_full (2, g_free);
-		g_ptr_array_add (cap_params, g_strdup ("REQ"));
-		g_ptr_array_add (cap_params, g_strdup ("sasl"));
-		IrciumMessage* cap_cmd =
-		  ircium_message_new (NULL, NULL, "CAP", cap_params);
-		int ret = irc_write_message (&s, cap_cmd);
-		g_free (g_ptr_array_free (cap_params, TRUE));
-
-		GPtrArray* auth_params = g_ptr_array_new_full (1, g_free);
-		g_ptr_array_add (auth_params, g_strdup ("PLAIN"));
-		IrciumMessage* auth_cmd =
-		  ircium_message_new (NULL, NULL, "AUTHENTICATE", auth_params);
-		ret |= irc_write_message (&s, auth_cmd);
-		g_free (g_ptr_array_free (auth_params, TRUE));
-	}
+	// Calling exec_hooks with a NULL message executes the PREINIT hooks
+	exec_hooks(&s, NULL);
 
 	/* Init Event Loop handels auth via sasl and breaks on
 	 * receiving either a MODE or WELCOME message.
 	 */
-    irc_do_event_loop (&s);
+	irc_do_event_loop (&s);
 
 	return 0;
 }

--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,7 @@ CIRC_SSL=true \
 CIRC_NICK=circ \
 CIRC_REALNAME=https://github.com/gnulag/circ/ \
 CIRC_IDENT=circ \
+CIRC_SASL_ENABLED=false \
 CIRC_AUTH_USER=circ \
 CIRC_AUTH_PASS=circ \
 CIRC_CHANNEL=#gnulag \


### PR DESCRIPTION
This is done through a global GHashTable to hook commands to a linked list of functions to call. A special PREINIT command used to allow for executing functions before registering the client. However, since client registration is done in PREINIT, it has to be the last element in the linked list. This is only done by hooking it after every other PREINIT hook. exec_hooks runs PREINIT hooks when msg is NULL, it runs "*" hooks when msg is 1, else it grabs the command from the message and runs all hooks for that command. "\*" hooks run for every single message. This is to allow something like an module engine to run its own hooks interface.

This allowed a lot of code to be moved from main and the callback to a file containing core hooks. It also makes irc_init_loop_callback unnecessary.

We can use this to start developing modules in C, although the plan is to use a scheme interpreter and to provide it with an API for developing modules.