### PR TITLE
Get the modules to work and add functions to access IRC information

### DIFF
--- a/libirc/irc.c
+++ b/libirc/irc.c
@@ -321,7 +321,7 @@ irc_write_message (const irc_server* s, const IrciumMessage* message)
 	size_t size = len;
 	int ret = irc_write_bytes (s, (char*)data, size);
 
-	g_object_unref ((gpointer) message);
+	g_object_unref ((gpointer)message);
 
 	return ret;
 }

--- a/scheme_mods/echo.scm
+++ b/scheme_mods/echo.scm
@@ -1,0 +1,4 @@
+(define (echo)
+  (reply (cadr (get-message-params))))
+
+(register-command "echo" echo)

--- a/scheme_mods/echo.scm
+++ b/scheme_mods/echo.scm
@@ -1,4 +1,10 @@
+(import (chibi string))
+
 (define (echo)
-  (reply (cadr (get-message-params))))
+  (let*
+    ((text (cadr (get-message-params)))
+     (words (string-split text))
+     (rest (string-join (cdr words) " ")))
+    (reply rest)))
 
 (register-command "echo" echo)

--- a/scheme_mods/pingpong.scm
+++ b/scheme_mods/pingpong.scm
@@ -1,8 +1,8 @@
 (define (pong)
-  (reply "pong"))
+  (reply (string-append (get-cmd-prefix) "pong")))
 
 (define (ping)
-  (reply "ping"))
+  (reply (string-append (get-cmd-prefix) "ping")))
 
 (register-command "ping" pong)
 (register-command "pong" ping)

--- a/scheme_mods/pingpong.scm
+++ b/scheme_mods/pingpong.scm
@@ -1,4 +1,8 @@
 (define (pong)
   (reply "pong"))
 
+(define (ping)
+  (reply "ping"))
+
 (register-command "ping" pong)
+(register-command "pong" ping)

--- a/src/circ.c
+++ b/src/circ.c
@@ -64,6 +64,7 @@ main (int argc, char** argv)
 	}
 
 	init_hooks ();
+	setenv ("CHIBI_MODULE_PATH", "chibi-scheme/lib", 1);
 	scm_init ();
 	register_core_hooks ();
 

--- a/src/scheme/scheme.c
+++ b/src/scheme/scheme.c
@@ -134,8 +134,8 @@ scm_run_module_entry (mod_entry* me,
 	me->mod->mod_ctx.serv = s;
 	me->mod->mod_ctx.msg = msg;
 	sexp res = sexp_apply (ctx, me->func, SEXP_NULL);
-	if (sexp_exceptionp(res))
-		sexp_print_exception(ctx, res, sexp_current_error_port (ctx));
+	if (sexp_exceptionp (res))
+		sexp_print_exception (ctx, res, sexp_current_error_port (ctx));
 
 	pthread_mutex_unlock (&me->mod->mtx);
 }

--- a/src/scheme/scheme.c
+++ b/src/scheme/scheme.c
@@ -45,8 +45,6 @@ scm_run_module_entry (mod_entry* me,
                       const irc_server* s,
                       const IrciumMessage* msg);
 static void
-to_scheme (const irc_server* s, const IrciumMessage* msg);
-static void
 scm_load_modules (char* dir);
 static scm_module*
 scm_create_module (char* path);
@@ -132,9 +130,13 @@ scm_run_module_entry (mod_entry* me,
                       const IrciumMessage* msg)
 {
 	pthread_mutex_lock (&me->mod->mtx);
+	sexp ctx = me->mod->scm_ctx;
 	me->mod->mod_ctx.serv = s;
 	me->mod->mod_ctx.msg = msg;
-	sexp_apply (me->mod->scm_ctx, me->func, SEXP_NULL);
+	sexp res = sexp_apply (ctx, me->func, SEXP_NULL);
+	if (sexp_exceptionp(res))
+		sexp_print_exception(ctx, res, sexp_current_error_port (ctx));
+
 	pthread_mutex_unlock (&me->mod->mtx);
 }
 

--- a/src/scheme/scheme.c
+++ b/src/scheme/scheme.c
@@ -170,6 +170,8 @@ scm_load_modules (char* dir)
 			scm_create_module (fe->fts_path);
 		}
 	log_info ("-----\n");
+
+	fts_close(f):
 }
 
 static scm_module*

--- a/src/scheme/scheme.c
+++ b/src/scheme/scheme.c
@@ -171,7 +171,7 @@ scm_load_modules (char* dir)
 		}
 	log_info ("-----\n");
 
-	fts_close(f):
+	fts_close (f);
 }
 
 static scm_module*

--- a/src/scheme/scmapi.c
+++ b/src/scheme/scmapi.c
@@ -30,7 +30,7 @@ scmapi_register_command (sexp ctx, sexp self, sexp n, sexp cmd, sexp func)
 }
 
 sexp
-scmapi_reply (sexp ctx, sexp self, sexp text)
+scmapi_reply (sexp ctx, sexp self, sexp n, sexp text)
 {
 	scm_module* mod = get_module (ctx);
 

--- a/src/scheme/scmapi.c
+++ b/src/scheme/scmapi.c
@@ -20,8 +20,8 @@ GPtrArray_to_scheme_list (sexp ctx, const GPtrArray* arr, int index)
 		return SEXP_NULL;
 	else
 		return sexp_cons (ctx,
-		                  sexp_c_string (ctx, (char*)arr->pdata[index], -1),
-		                  GPtrArray_to_scheme_list (ctx, arr, index + 1));
+				  sexp_c_string (ctx, (char*)arr->pdata[index], -1),
+				  GPtrArray_to_scheme_list (ctx, arr, index + 1));
 }
 
 sexp
@@ -52,7 +52,7 @@ scmapi_send_raw (sexp ctx, sexp self, sexp n, sexp raw)
 
 	if (!sexp_stringp (raw)) {
 		printf ("scmapi_send_raw: %s: The argument is not a string\n",
-		        mod->path);
+			mod->path);
 		return SEXP_NULL;
 	}
 

--- a/src/scheme/scmapi.c
+++ b/src/scheme/scmapi.c
@@ -1,6 +1,8 @@
+#include <string.h>
+
+#include "../config/config.h"
 #include "irc/irc.h"
 #include "scheme.h"
-#include <string.h>
 
 static scm_module*
 get_module (sexp ctx)
@@ -9,6 +11,15 @@ get_module (sexp ctx)
 	  sexp_eval_string (ctx, "circ-module-id", -1, sexp_context_env (ctx));
 	int id = sexp_unbox_fixnum (idobj);
 	return scm_get_module_from_id (id);
+}
+
+static sexp
+GPtrArray_to_scheme_list (sexp ctx, const GPtrArray *arr, int index)
+{
+	if (arr->len == index)
+		return SEXP_NULL;
+	else
+		return sexp_cons(ctx, sexp_c_string(ctx, (char* )arr->pdata[index], -1), GPtrArray_to_scheme_list(ctx, arr, index + 1));
 }
 
 sexp
@@ -30,15 +41,34 @@ scmapi_register_command (sexp ctx, sexp self, sexp n, sexp cmd, sexp func)
 }
 
 sexp
-scmapi_reply (sexp ctx, sexp self, sexp n, sexp text)
+scmapi_send_raw (sexp ctx, sexp self, sexp n, sexp raw)
 {
+	
 	scm_module* mod = get_module (ctx);
-
 	if (mod == NULL)
 		return SEXP_NULL;
 
-	if (!sexp_stringp(text)) {
-		printf("scmapi_reply: %s: The argument is not a string\n", mod->path);
+	if (!sexp_stringp (raw)) {
+		printf ("scmapi_send_raw: %s: The argument is not a string\n", mod->path);
+		return SEXP_NULL;
+	}
+
+	const irc_server* s = mod->mod_ctx.serv;
+	const char* raw_c = sexp_string_data (raw);
+	irc_write_bytes (s, raw_c, strlen (raw_c));
+
+	return SEXP_NULL;
+}
+
+sexp
+scmapi_reply (sexp ctx, sexp self, sexp n, sexp text)
+{
+	scm_module* mod = get_module (ctx);
+	if (mod == NULL)
+		return SEXP_NULL;
+
+	if (!sexp_stringp (text)) {
+		printf ("scmapi_reply: %s: The argument is not a string\n", mod->path);
 		return SEXP_NULL;
 	}
 
@@ -57,6 +87,68 @@ scmapi_reply (sexp ctx, sexp self, sexp n, sexp text)
 	return SEXP_NULL;
 }
 
+sexp
+scmapi_get_cmd_prefix (sexp ctx, sexp self, sexp n)
+{
+	config_t* config = get_config ();
+	return sexp_c_string (ctx, config->cmd_prefix, -1);
+}
+
+sexp
+scmapi_get_server_name (sexp ctx, sexp self, sexp n)
+{
+	scm_module* mod = get_module (ctx);
+	if (mod == NULL)
+		return SEXP_NULL;
+
+	const irc_server* s = mod->mod_ctx.serv;
+	return sexp_c_string(ctx, s->name, -1);
+}
+
+sexp
+scmapi_get_message_source (sexp ctx, sexp self, sexp n)
+{
+	scm_module* mod = get_module (ctx);
+	if (mod == NULL)
+		return SEXP_NULL;
+
+	const IrciumMessage* msg = mod->mod_ctx.msg;
+	return sexp_c_string(ctx, (char* )ircium_message_get_source (msg), -1);
+}
+
+sexp
+scmapi_get_message_command (sexp ctx, sexp self, sexp n)
+{
+	scm_module* mod = get_module (ctx);
+	if (mod == NULL)
+		return SEXP_NULL;
+
+	const IrciumMessage* msg = mod->mod_ctx.msg;
+	return sexp_c_string(ctx, (char* )ircium_message_get_command (msg), -1);
+}
+
+sexp
+scmapi_get_message_tags (sexp ctx, sexp self, sexp n)
+{
+	scm_module* mod = get_module (ctx);
+	if (mod == NULL)
+		return SEXP_NULL;
+
+	const IrciumMessage* msg = mod->mod_ctx.msg;
+	return GPtrArray_to_scheme_list(ctx, ircium_message_get_tags (msg), 0);
+}
+
+sexp
+scmapi_get_message_params (sexp ctx, sexp self, sexp n)
+{
+	scm_module* mod = get_module (ctx);
+	if (mod == NULL)
+		return SEXP_NULL;
+
+	const IrciumMessage* msg = mod->mod_ctx.msg;
+	return GPtrArray_to_scheme_list(ctx, ircium_message_get_params (msg), 0);
+}
+
 void
 scmapi_define_foreign_functions (sexp ctx)
 {
@@ -65,4 +157,12 @@ scmapi_define_foreign_functions (sexp ctx)
 	sexp_define_foreign (
 	  ctx, env, "register-command", 2, scmapi_register_command);
 	sexp_define_foreign (ctx, env, "reply", 1, scmapi_reply);
+	sexp_define_foreign (ctx, env, "send-raw", 1, scmapi_send_raw);
+	sexp_define_foreign (ctx, env, "get-cmd-prefix", 0, scmapi_get_cmd_prefix);
+
+	sexp_define_foreign (ctx, env, "get-server-name", 0, scmapi_get_server_name);
+	sexp_define_foreign (ctx, env, "get-message-source", 0, scmapi_get_message_source);
+	sexp_define_foreign (ctx, env, "get-message-command", 0, scmapi_get_message_command);
+	sexp_define_foreign (ctx, env, "get-message-params", 0, scmapi_get_message_params);
+	sexp_define_foreign (ctx, env, "get-message-tags", 0, scmapi_get_message_tags);
 }

--- a/src/scheme/scmapi.c
+++ b/src/scheme/scmapi.c
@@ -14,12 +14,14 @@ get_module (sexp ctx)
 }
 
 static sexp
-GPtrArray_to_scheme_list (sexp ctx, const GPtrArray *arr, int index)
+GPtrArray_to_scheme_list (sexp ctx, const GPtrArray* arr, int index)
 {
 	if (arr->len == index)
 		return SEXP_NULL;
 	else
-		return sexp_cons(ctx, sexp_c_string(ctx, (char* )arr->pdata[index], -1), GPtrArray_to_scheme_list(ctx, arr, index + 1));
+		return sexp_cons (ctx,
+		                  sexp_c_string (ctx, (char*)arr->pdata[index], -1),
+		                  GPtrArray_to_scheme_list (ctx, arr, index + 1));
 }
 
 sexp
@@ -43,13 +45,14 @@ scmapi_register_command (sexp ctx, sexp self, sexp n, sexp cmd, sexp func)
 sexp
 scmapi_send_raw (sexp ctx, sexp self, sexp n, sexp raw)
 {
-	
+
 	scm_module* mod = get_module (ctx);
 	if (mod == NULL)
 		return SEXP_NULL;
 
 	if (!sexp_stringp (raw)) {
-		printf ("scmapi_send_raw: %s: The argument is not a string\n", mod->path);
+		printf ("scmapi_send_raw: %s: The argument is not a string\n",
+		        mod->path);
 		return SEXP_NULL;
 	}
 
@@ -102,7 +105,7 @@ scmapi_get_server_name (sexp ctx, sexp self, sexp n)
 		return SEXP_NULL;
 
 	const irc_server* s = mod->mod_ctx.serv;
-	return sexp_c_string(ctx, s->name, -1);
+	return sexp_c_string (ctx, s->name, -1);
 }
 
 sexp
@@ -113,7 +116,7 @@ scmapi_get_message_source (sexp ctx, sexp self, sexp n)
 		return SEXP_NULL;
 
 	const IrciumMessage* msg = mod->mod_ctx.msg;
-	return sexp_c_string(ctx, (char* )ircium_message_get_source (msg), -1);
+	return sexp_c_string (ctx, (char*)ircium_message_get_source (msg), -1);
 }
 
 sexp
@@ -124,7 +127,7 @@ scmapi_get_message_command (sexp ctx, sexp self, sexp n)
 		return SEXP_NULL;
 
 	const IrciumMessage* msg = mod->mod_ctx.msg;
-	return sexp_c_string(ctx, (char* )ircium_message_get_command (msg), -1);
+	return sexp_c_string (ctx, (char*)ircium_message_get_command (msg), -1);
 }
 
 sexp
@@ -135,7 +138,7 @@ scmapi_get_message_tags (sexp ctx, sexp self, sexp n)
 		return SEXP_NULL;
 
 	const IrciumMessage* msg = mod->mod_ctx.msg;
-	return GPtrArray_to_scheme_list(ctx, ircium_message_get_tags (msg), 0);
+	return GPtrArray_to_scheme_list (ctx, ircium_message_get_tags (msg), 0);
 }
 
 sexp
@@ -146,23 +149,37 @@ scmapi_get_message_params (sexp ctx, sexp self, sexp n)
 		return SEXP_NULL;
 
 	const IrciumMessage* msg = mod->mod_ctx.msg;
-	return GPtrArray_to_scheme_list(ctx, ircium_message_get_params (msg), 0);
+	return GPtrArray_to_scheme_list (ctx, ircium_message_get_params (msg), 0);
 }
 
 void
 scmapi_define_foreign_functions (sexp ctx)
 {
 	sexp env = sexp_context_env (ctx);
+
+	/* Entry registrations */
 	sexp_define_foreign (ctx, env, "register-hook", 2, scmapi_register_hook);
 	sexp_define_foreign (
 	  ctx, env, "register-command", 2, scmapi_register_command);
+
+	/* Server interactions */
 	sexp_define_foreign (ctx, env, "reply", 1, scmapi_reply);
 	sexp_define_foreign (ctx, env, "send-raw", 1, scmapi_send_raw);
+
+	/* IRC config information */
 	sexp_define_foreign (ctx, env, "get-cmd-prefix", 0, scmapi_get_cmd_prefix);
 
-	sexp_define_foreign (ctx, env, "get-server-name", 0, scmapi_get_server_name);
-	sexp_define_foreign (ctx, env, "get-message-source", 0, scmapi_get_message_source);
-	sexp_define_foreign (ctx, env, "get-message-command", 0, scmapi_get_message_command);
-	sexp_define_foreign (ctx, env, "get-message-params", 0, scmapi_get_message_params);
-	sexp_define_foreign (ctx, env, "get-message-tags", 0, scmapi_get_message_tags);
+	/* Server information */
+	sexp_define_foreign (
+	  ctx, env, "get-server-name", 0, scmapi_get_server_name);
+
+	/* message information */
+	sexp_define_foreign (
+	  ctx, env, "get-message-source", 0, scmapi_get_message_source);
+	sexp_define_foreign (
+	  ctx, env, "get-message-command", 0, scmapi_get_message_command);
+	sexp_define_foreign (
+	  ctx, env, "get-message-params", 0, scmapi_get_message_params);
+	sexp_define_foreign (
+	  ctx, env, "get-message-tags", 0, scmapi_get_message_tags);
 }


### PR DESCRIPTION
This brings up to a point where we can start writing simple modules. We'll have to add functions to the API as we go.

However, CHIBI_MODULE_PATH needs to be set to chibi-scheme/lib for it to access the standard library. I set it from within the code for now