### PR TITLE
Regex modules

### DIFF
--- a/scheme_mods/intensify.scm
+++ b/scheme_mods/intensify.scm
@@ -1,0 +1,12 @@
+(import (chibi string))
+
+(define (intensify)
+  (let*
+    ((text (cadr (get-message-params)))
+     (inner-text (string-trim-left
+		  (string-trim-right text #\])
+		  #\[)))
+     (reply (string-map char-upcase
+	      (string-append "" inner-text " intensifies" "")))))
+
+(register-match "^\\[.+\\]$" intensify)

--- a/src/scheme/scheme.h
+++ b/src/scheme/scheme.h
@@ -29,6 +29,8 @@ scm_add_irc_hook (const char *command, sexp func, scm_module *mod);
 void
 scm_add_command_hook (const char *command, sexp func, scm_module *mod);
 void
+scm_add_regex_hook (const char *rx_str, sexp func, scm_module *mod);
+void
 scmapi_define_foreign_functions (sexp ctx);
 
 #endif

--- a/src/scheme/scmapi.c
+++ b/src/scheme/scmapi.c
@@ -49,6 +49,18 @@ scmapi_register_command (sexp ctx, sexp self, sexp n, sexp cmd, sexp func)
 }
 
 sexp
+scmapi_register_match (sexp ctx, sexp self, sexp n, sexp regex, sexp func)
+{
+	scm_module *mod = get_module (ctx);
+	if (mod == NULL)
+		return SEXP_FALSE;
+
+	const char *regex_c = sexp_string_data (regex);
+	scm_add_regex_hook (regex_c, func, mod);
+	return SEXP_TRUE;
+}
+
+sexp
 scmapi_send_raw (sexp ctx, sexp self, sexp n, sexp raw)
 {
 
@@ -165,8 +177,8 @@ scmapi_define_foreign_functions (sexp ctx)
 
 	/* Entry registrations */
 	sexp_define_foreign (ctx, env, "register-hook", 2, scmapi_register_hook);
-	sexp_define_foreign (
-	  ctx, env, "register-command", 2, scmapi_register_command);
+	sexp_define_foreign (ctx, env, "register-command", 2, scmapi_register_command);
+	sexp_define_foreign (ctx, env, "register-match", 2, scmapi_register_match);
 
 	/* Server interactions */
 	sexp_define_foreign (ctx, env, "reply", 1, scmapi_reply);


### PR DESCRIPTION
Add regex hooks to modules. Regex hooks match POSIX regex rules against messages and execute the given function if the message matches the regex.