### PR TITLE
Exit if the nickname is already in use

### DIFF
--- a/log/log.c
+++ b/log/log.c
@@ -29,6 +29,8 @@ log_error (char *fmt, ...)
 {
 	va_list argptr;
 	va_start (argptr, fmt);
+
+	fputs ("Error: ", stderr);
 	vfprintf (stderr, fmt, argptr);
 	va_end (argptr);
 }

--- a/log/log.c
+++ b/log/log.c
@@ -23,3 +23,12 @@ log_info (char *fmt, ...)
 	vprintf (fmt, argptr);
 	va_end (argptr);
 }
+
+void
+log_error (char *fmt, ...)
+{
+	va_list argptr;
+	va_start (argptr, fmt);
+	vfprintf (stderr, fmt, argptr);
+	va_end (argptr);
+}

--- a/log/log.h
+++ b/log/log.h
@@ -11,4 +11,7 @@ log_info (char *fmt, ...);
 void
 log_debug (char *fmt, ...);
 
+void
+log_error (char *fmt, ...);
+
 #endif /* LOG_H */

--- a/src/core_hooks.c
+++ b/src/core_hooks.c
@@ -86,7 +86,8 @@ sasl_cap_hook (const irc_server *s, const irc_msg *msg)
 static void
 sasl_error_hook (const irc_server *s, const irc_msg *msg)
 {
-	err (1, "Error during SASL Auth");
+	log_error ("Error during SASL Auth\n");
+	raise (SIGINT);
 }
 
 static void
@@ -129,6 +130,13 @@ invite_hook (const irc_server *s, const irc_msg *msg)
 	irc_push_message (s, join_msg);
 }
 
+static void
+err_nickname_in_use_hook (const irc_server *s, const irc_msg *msg)
+{
+	log_error ("Nickname already in use\n");
+	raise (SIGINT);
+}
+
 void
 register_core_hooks ()
 {
@@ -147,4 +155,5 @@ register_core_hooks ()
 	add_hook ("INVITE", invite_hook);
 	add_hook ("PING", ping_hook);
 	add_hook ("001", channel_join_hook);
+	add_hook ("433", err_nickname_in_use_hook);
 }


### PR DESCRIPTION
After some discussion with @maxaudron, we decided to just implement this case by printing an error and exiting.
I also created a new function, `log_error`, that works basically the same as `log_info` except it prints to `stderr` and prepends `Error: ` to the message, to make it clear to the user it's an error. I also changed `sasl_error_hook` to use this function instead of `err`.